### PR TITLE
feat(mux): channel-agnostic tokens, bg retry, model template

### DIFF
--- a/mux-server/test/server.test.ts
+++ b/mux-server/test/server.test.ts
@@ -4,7 +4,6 @@ import http from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { WebSocketServer, type WebSocket } from "ws";
@@ -383,7 +382,7 @@ async function createAdminPairingToken(params: {
   openclawId: string;
   inboundUrl?: string;
   inboundTimeoutMs?: number;
-  channel: string;
+  channel?: string;
   sessionKey?: string;
   ttlSec?: number;
 }) {
@@ -395,7 +394,6 @@ async function createAdminPairingToken(params: {
     },
     body: JSON.stringify({
       openclawId: params.openclawId,
-      channel: params.channel,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       ...(params.ttlSec ? { ttlSec: params.ttlSec } : {}),
       ...(params.inboundUrl ? { inboundUrl: params.inboundUrl } : {}),
@@ -477,9 +475,7 @@ describe("mux server", () => {
       message: "Telegram getUpdates returned 409; another poller is using this bot token.",
     });
     expect(typeof telegramInbound?.lastConflictAtMs).toBe("number");
-    expect(JSON.stringify(telegramInbound?.lastError ?? "")).toContain(
-      "telegram getUpdates failed (409)",
-    );
+    expect(JSON.stringify(telegramInbound?.lastError ?? "")).toContain("getUpdates failed (409)");
   });
 
   test("instance register endpoint requires shared register key and returns runtime jwt metadata", async () => {
@@ -2332,7 +2328,7 @@ describe("mux server", () => {
     });
   });
 
-  test("retries Telegram inbound without advancing offset when forward fails", async () => {
+  test("advances Telegram offset on forward failure and retries in background", async () => {
     const inboundAttempts: Array<Record<string, unknown>> = [];
     let failFirstForward = true;
     const inbound = await startHttpServer(async (req, res) => {
@@ -2405,6 +2401,8 @@ describe("mux server", () => {
         MUX_TELEGRAM_POLL_TIMEOUT_SEC: "1",
         MUX_TELEGRAM_POLL_RETRY_MS: "50",
         MUX_TELEGRAM_BOOTSTRAP_LATEST: "false",
+        // Short retry interval for test speed
+        MUX_TELEGRAM_BG_RETRY_INTERVAL_MS: "100",
       },
     });
 
@@ -2417,19 +2415,22 @@ describe("mux server", () => {
     expect(claim.status).toBe(200);
     releaseUpdates = true;
 
+    // The poller should advance the offset immediately (to 462) even though
+    // the first forward fails. The background retry delivers the message.
     await waitForCondition(
       () => inboundAttempts.length >= 2,
       6_000,
-      "timed out waiting for telegram retry forward",
+      "timed out waiting for telegram background retry",
     );
 
     expect(inboundAttempts[0]?.body).toBe("retry telegram message");
     expect(inboundAttempts[1]?.body).toBe("retry telegram message");
 
+    // Offset should advance past 461 after the first (failed) attempt —
+    // the poller must NOT re-poll with offset=1 twice.
     const seenOffsets = telegramRequests
       .map((request) => (typeof request.offset === "number" ? Number(request.offset) : null))
       .filter((offset): offset is number => offset !== null);
-    expect(seenOffsets.filter((offset) => offset === 1).length).toBeGreaterThanOrEqual(2);
     expect(seenOffsets.some((offset) => offset === 462)).toBe(true);
   }, 15_000);
 
@@ -3622,7 +3623,6 @@ describe("mux server", () => {
       port: server.port,
       adminToken: DEFAULT_ADMIN_TOKEN,
       openclawId: "tenant-a",
-      channel: "discord",
       ttlSec: 120,
     });
     expect(tokenResponse.status).toBe(200);
@@ -3632,8 +3632,6 @@ describe("mux server", () => {
       startCommand?: string | null;
     };
     expect(tokenBody.token.startsWith("mpt_")).toBe(true);
-    expect(tokenBody.deepLink ?? null).toBeNull();
-    expect(tokenBody.startCommand ?? null).toBeNull();
 
     gatewayState.pairingToken = tokenBody.token;
     dispatchGatewayMessages();
@@ -4586,14 +4584,12 @@ describe("mux server", () => {
       port: server.port,
       adminToken: DEFAULT_ADMIN_TOKEN,
       openclawId: "tenant-a",
-      channel: "discord",
       sessionKey: "dc:dm:777777",
       ttlSec: 120,
     });
     expect(firstToken.status).toBe(200);
     expect(await firstToken.json()).toMatchObject({
       ok: true,
-      channel: "discord",
       token: expect.stringMatching(/^mpt_/),
     });
 
@@ -4601,18 +4597,16 @@ describe("mux server", () => {
       port: server.port,
       adminToken: DEFAULT_ADMIN_TOKEN,
       openclawId: "tenant-b",
-      channel: "discord",
       sessionKey: "dc:dm:777777",
       ttlSec: 120,
     });
     expect(secondToken.status).toBe(200);
     expect(await secondToken.json()).toMatchObject({
       ok: true,
-      channel: "discord",
     });
   }, 15_000);
 
-  test("does not consume discord token when first claim attempt is invalid", async () => {
+  test("channel-agnostic token can be claimed by any channel", async () => {
     const dmChannelId = "997001";
     const dmUserId = "9090";
     const sentMessages: Array<Record<string, unknown>> = [];
@@ -4724,7 +4718,6 @@ describe("mux server", () => {
       port: server.port,
       adminToken: DEFAULT_ADMIN_TOKEN,
       openclawId: "tenant-a",
-      channel: "discord",
       sessionKey: "dc:dm:9090",
       ttlSec: 120,
     });
@@ -4736,39 +4729,17 @@ describe("mux server", () => {
       "timed out waiting for discord gateway identify before token claim",
     );
 
-    const dbPath = resolve(server.tempDir, "mux-server.sqlite");
-    const db = new DatabaseSync(dbPath);
-    db.prepare(
-      "UPDATE pairing_tokens SET channel = 'telegram' WHERE tenant_id = ? AND channel = 'discord' AND consumed_at_ms IS NULL",
-    ).run("tenant-a");
-    db.close();
-
+    // Token issued without channel — should be claimable by discord
     dispatchMessage("1001", tokenBody.token, "2026-01-01T00:00:01.000Z");
-
-    await waitForCondition(
-      () => sentMessages.some((message) => toSafeString(message.content).includes("Invalid token")),
-      6_000,
-      "timed out waiting for failed discord token claim",
-    );
-
-    const dbRestore = new DatabaseSync(dbPath);
-    dbRestore
-      .prepare(
-        "UPDATE pairing_tokens SET channel = 'discord' WHERE tenant_id = ? AND channel = 'telegram' AND consumed_at_ms IS NULL",
-      )
-      .run("tenant-a");
-    dbRestore.close();
-
-    dispatchMessage("1002", tokenBody.token, "2026-01-01T00:00:02.000Z");
 
     await waitForCondition(
       () => sentMessages.some((message) => toSafeString(message.content).includes("Paired")),
       6_000,
-      "timed out waiting for successful discord token claim after failure",
+      "timed out waiting for channel-agnostic discord token claim",
     );
   }, 20_000);
 
-  test("issues whatsapp pairing token without deep link or start command", async () => {
+  test("issues channel-agnostic pairing token with telegram deep link", async () => {
     const server = await startServer({
       tenantsJson: JSON.stringify([{ id: "tenant-a", name: "Tenant A", apiKey: "tenant-a-key" }]),
     });
@@ -4777,18 +4748,17 @@ describe("mux server", () => {
       port: server.port,
       adminToken: DEFAULT_ADMIN_TOKEN,
       openclawId: "tenant-a",
-      channel: "whatsapp",
       sessionKey: "agent:main:whatsapp:direct:+15550001111",
       ttlSec: 120,
     });
     expect(tokenResponse.status).toBe(200);
-    expect(await tokenResponse.json()).toMatchObject({
+    const body = await tokenResponse.json();
+    expect(body).toMatchObject({
       ok: true,
-      channel: "whatsapp",
       token: expect.stringMatching(/^mpt_/),
-      deepLink: null,
-      startCommand: null,
     });
+    // Channel-agnostic tokens always include telegram startCommand and deepLink
+    expect(typeof (body as Record<string, unknown>).startCommand).toBe("string");
   });
 
   test("whatsapp outbound accepts legacy text envelope", async () => {

--- a/phala-deploy/gen-cvm-config.sh
+++ b/phala-deploy/gen-cvm-config.sh
@@ -65,17 +65,21 @@ CONFIG_JSON=$(node -e "
     },
   };
 
-  // Model config — Codex via sub2api
+  // Model config — Codex via sub2api.
+  // Preserve template-provided model definitions and only inject runtime auth/baseUrl.
   cfg.agents.defaults.model = { primary: process.argv[6] };
-  cfg.models = {
-    providers: {
-      'openai-codex': {
-        baseUrl: process.argv[7],
-        apiKey: process.argv[8],
-        headers: { 'x-api-key': process.argv[9] },
-        models: [],
-      },
+  cfg.models = cfg.models || {};
+  cfg.models.providers = cfg.models.providers || {};
+  const codexProvider = cfg.models.providers['openai-codex'] || {};
+  cfg.models.providers['openai-codex'] = {
+    ...codexProvider,
+    baseUrl: process.argv[7],
+    apiKey: process.argv[8],
+    headers: {
+      ...(codexProvider.headers || {}),
+      'x-api-key': process.argv[9],
     },
+    models: Array.isArray(codexProvider.models) ? codexProvider.models : [],
   };
 
   // Brave Search web tool (optional)

--- a/phala-deploy/mux-server-compose.yml
+++ b/phala-deploy/mux-server-compose.yml
@@ -1,6 +1,6 @@
 services:
   mux-server:
-    image: h4x3rotab/openclaw-mux@sha256:2cc98cc0d9acececdb665caf4713ae4ae562ba1ce3ff81218f107b7a2b1cecc1
+    image: h4x3rotab/openclaw-mux@sha256:cfe6eda026525ed31f784e725fe7d0b1788febea78f5c2e97444d7d00c02f711
     container_name: mux-server
     ports:
       - "1022:22"
@@ -27,6 +27,11 @@ services:
       - mux_data:/data
       - mux_credentials:/root/.openclaw/credentials
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
 
 volumes:
   mux_data:

--- a/phala-deploy/openclaw.template.json
+++ b/phala-deploy/openclaw.template.json
@@ -58,6 +58,27 @@
       "compaction": { "mode": "safeguard" }
     }
   },
+  "models": {
+    "providers": {
+      "openai-codex": {
+        "baseUrl": "https://example.invalid/v1",
+        "apiKey": "set-by-gen-cvm-config",
+        "headers": { "x-api-key": "set-by-gen-cvm-config" },
+        "models": [
+          { "id": "gpt-5.3-codex", "name": "gpt-5.3-codex" },
+          { "id": "gpt-5.2-codex", "name": "gpt-5.2-codex" },
+          { "id": "gpt-5.1-codex-max", "name": "gpt-5.1-codex-max" },
+          { "id": "gpt-5.1-codex", "name": "gpt-5.1-codex" },
+          { "id": "gpt-5.2", "name": "gpt-5.2" },
+          { "id": "gpt-5.1", "name": "gpt-5.1" },
+          { "id": "gpt-5-codex", "name": "gpt-5-codex" },
+          { "id": "gpt-5", "name": "gpt-5" },
+          { "id": "gpt-5.1-codex-mini", "name": "gpt-5.1-codex-mini" },
+          { "id": "gpt-5-codex-mini", "name": "gpt-5-codex-mini" }
+        ]
+      }
+    }
+  },
   "skills": {
     "entries": {
       "gog": { "enabled": false },


### PR DESCRIPTION
## Summary
- Remove channel field from pairing tokens — tokens are now channel-agnostic and claimable by any platform
- Add background retry with per-tenant cap for Telegram and Discord inbound forwarding
- Preserve template-provided model definitions in `gen-cvm-config.sh` instead of overwriting
- Add full model list to `openclaw.template.json`
- Update mux-server compose image digest and add container log rotation
- Fix unused import lint error in tests

## Test plan
- [x] Mux server deployed to `openclaw-mux-dev` and health check passes
- [ ] Verify channel-agnostic token claiming works across Telegram/Discord/WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)