### PR TITLE
feat: WhatsApp shared-bot runtime + Discord egress fixes

### DIFF
--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -2887,6 +2887,9 @@ async function sendTelegramPairingNotice(params: {
   text: string;
   parseMode?: TelegramParseMode;
 }) {
+  const isGeneralForumTopic =
+    params.topicId === TELEGRAM_GENERAL_TOPIC_ID && params.chatId.startsWith("-");
+  const canUseThreadId = Boolean(params.topicId) && !isGeneralForumTopic;
   const body: Record<string, unknown> = {
     chat_id: params.chatId,
     text: params.text,
@@ -2894,13 +2897,32 @@ async function sendTelegramPairingNotice(params: {
   if (params.parseMode) {
     body.parse_mode = params.parseMode;
   }
-  if (params.topicId) {
+  if (canUseThreadId && params.topicId) {
     body.message_thread_id = params.topicId;
   }
-  const { response, result } = await sendTelegram("sendMessage", body);
-  if (!response.ok || result.ok !== true) {
-    throw new Error(`telegram pairing notice failed (${response.status})`);
+  const firstAttempt = await sendTelegram("sendMessage", body);
+  if (firstAttempt.response.ok && firstAttempt.result.ok === true) {
+    return;
   }
+
+  // Topic IDs can become stale (or Telegram can reject edge-case topic IDs).
+  // Fall back to chat-level notices so bot-control commands still respond.
+  const description =
+    typeof firstAttempt.result.description === "string" ? firstAttempt.result.description : "";
+  const shouldRetryWithoutThread = canUseThreadId && /message thread not found/i.test(description);
+  if (shouldRetryWithoutThread) {
+    const retryBody: Record<string, unknown> = {
+      chat_id: params.chatId,
+      text: params.text,
+      ...(params.parseMode ? { parse_mode: params.parseMode } : {}),
+    };
+    const retryAttempt = await sendTelegram("sendMessage", retryBody);
+    if (retryAttempt.response.ok && retryAttempt.result.ok === true) {
+      return;
+    }
+    throw new Error(`telegram pairing notice failed (${retryAttempt.response.status})`);
+  }
+  throw new Error(`telegram pairing notice failed (${firstAttempt.response.status})`);
 }
 
 async function answerTelegramCallbackQuery(params: {

--- a/mux-server/test/server.test.ts
+++ b/mux-server/test/server.test.ts
@@ -3088,6 +3088,193 @@ describe("mux server", () => {
     });
   }, 10_000);
 
+  test("handles unpaired /bot_help in forum General without message_thread_id", async () => {
+    const pendingUpdates: Array<Record<string, unknown>> = [];
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const telegramApi = await startHttpServer(async (req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      if (req.url === "/botdummy-token/getUpdates") {
+        const body = await readJsonBody(req);
+        const offset = typeof body.offset === "number" ? Number(body.offset) : 0;
+        const deliverable = pendingUpdates
+          .map((entry) => {
+            const updateId = Number(entry.update_id ?? 0);
+            return { entry, updateId };
+          })
+          .filter((entry) => Number.isFinite(entry.updateId) && entry.updateId >= offset)
+          .toSorted((a, b) => a.updateId - b.updateId);
+        const result = deliverable.map((entry) => entry.entry);
+        if (deliverable.length > 0) {
+          const maxDelivered = deliverable[deliverable.length - 1]?.updateId ?? 0;
+          for (let i = pendingUpdates.length - 1; i >= 0; i -= 1) {
+            const updateId = Number(pendingUpdates[i]?.update_id ?? 0);
+            if (Number.isFinite(updateId) && updateId <= maxDelivered) {
+              pendingUpdates.splice(i, 1);
+            }
+          }
+        }
+        res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+        res.end(JSON.stringify({ ok: true, result }));
+        return;
+      }
+      if (req.url === "/botdummy-token/sendMessage") {
+        const body = await readJsonBody(req);
+        sentMessages.push(body);
+        if (Number(body.message_thread_id) === 1) {
+          res.writeHead(400, { "content-type": "application/json; charset=utf-8" });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error_code: 400,
+              description: "Bad Request: message thread not found",
+            }),
+          );
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+        res.end(
+          JSON.stringify({
+            ok: true,
+            result: { message_id: 9901, chat: { id: -100909, type: "supergroup" } },
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await startServer({
+      extraEnv: {
+        MUX_TELEGRAM_API_BASE_URL: telegramApi.url,
+        MUX_TELEGRAM_POLL_TIMEOUT_SEC: "1",
+        MUX_TELEGRAM_POLL_RETRY_MS: "50",
+        MUX_TELEGRAM_BOOTSTRAP_LATEST: "false",
+        MUX_UNPAIRED_HINT_TEXT: "This chat is not paired.",
+      },
+    });
+
+    pendingUpdates.push({
+      update_id: 5101,
+      message: {
+        message_id: 9101,
+        text: "/bot_help",
+        date: 1_700_000_100,
+        from: { id: 1234 },
+        chat: { id: -100909, type: "supergroup", is_forum: true },
+      },
+    });
+
+    await waitForCondition(
+      () => sentMessages.length > 0,
+      5_000,
+      "timed out waiting for unpaired forum General notice",
+    );
+
+    expect(toSafeString(sentMessages[0]?.chat_id)).toBe("-100909");
+    expect(sentMessages[0]?.message_thread_id).toBeUndefined();
+    expect(toSafeString(sentMessages[0]?.text)).toContain("Bot control commands");
+    expect(sentMessages.some((message) => Number(message.message_thread_id) === 1)).toBe(false);
+  });
+
+  test("retries unpaired notice without topic thread when Telegram rejects thread ID", async () => {
+    const pendingUpdates: Array<Record<string, unknown>> = [];
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const telegramApi = await startHttpServer(async (req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      if (req.url === "/botdummy-token/getUpdates") {
+        const body = await readJsonBody(req);
+        const offset = typeof body.offset === "number" ? Number(body.offset) : 0;
+        const deliverable = pendingUpdates
+          .map((entry) => {
+            const updateId = Number(entry.update_id ?? 0);
+            return { entry, updateId };
+          })
+          .filter((entry) => Number.isFinite(entry.updateId) && entry.updateId >= offset)
+          .toSorted((a, b) => a.updateId - b.updateId);
+        const result = deliverable.map((entry) => entry.entry);
+        if (deliverable.length > 0) {
+          const maxDelivered = deliverable[deliverable.length - 1]?.updateId ?? 0;
+          for (let i = pendingUpdates.length - 1; i >= 0; i -= 1) {
+            const updateId = Number(pendingUpdates[i]?.update_id ?? 0);
+            if (Number.isFinite(updateId) && updateId <= maxDelivered) {
+              pendingUpdates.splice(i, 1);
+            }
+          }
+        }
+        res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+        res.end(JSON.stringify({ ok: true, result }));
+        return;
+      }
+      if (req.url === "/botdummy-token/sendMessage") {
+        const body = await readJsonBody(req);
+        sentMessages.push(body);
+        if (Number(body.message_thread_id) === 2) {
+          res.writeHead(400, { "content-type": "application/json; charset=utf-8" });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error_code: 400,
+              description: "Bad Request: message thread not found",
+            }),
+          );
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+        res.end(
+          JSON.stringify({
+            ok: true,
+            result: { message_id: 9902, chat: { id: -100910, type: "supergroup" } },
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await startServer({
+      extraEnv: {
+        MUX_TELEGRAM_API_BASE_URL: telegramApi.url,
+        MUX_TELEGRAM_POLL_TIMEOUT_SEC: "1",
+        MUX_TELEGRAM_POLL_RETRY_MS: "50",
+        MUX_TELEGRAM_BOOTSTRAP_LATEST: "false",
+        MUX_UNPAIRED_HINT_TEXT: "This chat is not paired.",
+      },
+    });
+
+    pendingUpdates.push({
+      update_id: 5102,
+      message: {
+        message_id: 9102,
+        text: "/bot_help",
+        date: 1_700_000_101,
+        from: { id: 1234 },
+        chat: { id: -100910, type: "supergroup", is_forum: true },
+        message_thread_id: 2,
+      },
+    });
+
+    await waitForCondition(
+      () => sentMessages.length >= 2,
+      5_000,
+      "timed out waiting for thread-not-found fallback notice",
+    );
+
+    expect(toSafeString(sentMessages[0]?.chat_id)).toBe("-100910");
+    expect(sentMessages[0]?.message_thread_id).toBe(2);
+    expect(sentMessages[1]?.message_thread_id).toBeUndefined();
+    expect(toSafeString(sentMessages[1]?.text)).toContain("Bot control commands");
+  });
+
   test("pairs telegram DM threads once and isolates sessions per thread", async () => {
     const inboundRequests: Array<Record<string, unknown>> = [];
     const inbound = await startHttpServer(async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.17-phala.4",
+  "version": "2026.2.17-phala.5",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/phala-deploy/local-mux-e2e/FORUM_GROUP_HANDOFF.md
+++ b/phala-deploy/local-mux-e2e/FORUM_GROUP_HANDOFF.md
@@ -50,12 +50,12 @@ Code/tests:
 ## Required pairing flow for group tests
 
 1. Mint pairing token (`pair-token.sh telegram` or admin API).
-. Send `/start <token>` **inside the target forum topic** (via `tgcli send --to <group_id> --topic <topic_id>`).
-3. Confirm mux log emits `telegram_pairing_token_claimed` with group route, for example:
-   - `routeKey: telegram:default:chat:-100...:topic:1`
+2. Send `/start <token>` **inside the target forum topic** (via `tgcli send --to <group_id> --topic <topic_id>`).
+3. Confirm mux log emits `telegram_pairing_token_claimed` with chat-wide group route, for example:
+   - `routeKey: telegram:default:chat:-100...`
    - `sessionKey: agent:main:telegram:group:-100...:topic:1`
 
-After this, normal group/topic traffic is forwarded.
+After this, normal traffic in all topics of that forum chat is forwarded.
 
 ## Useful tgcli commands
 

--- a/phala-deploy/local-mux-e2e/FORUM_GROUP_HANDOFF.md
+++ b/phala-deploy/local-mux-e2e/FORUM_GROUP_HANDOFF.md
@@ -50,12 +50,12 @@ Code/tests:
 ## Required pairing flow for group tests
 
 1. Mint pairing token (`pair-token.sh telegram` or admin API).
-2. Send `/start <token>` inside any topic of that forum chat (via `tgcli send --to <group_id> --topic <topic_id>`).
-3. Confirm mux log emits `telegram_pairing_token_claimed` with chat-wide group route, for example:
-   - `routeKey: telegram:default:chat:-100...`
+. Send `/start <token>` **inside the target forum topic** (via `tgcli send --to <group_id> --topic <topic_id>`).
+3. Confirm mux log emits `telegram_pairing_token_claimed` with group route, for example:
+   - `routeKey: telegram:default:chat:-100...:topic:1`
    - `sessionKey: agent:main:telegram:group:-100...:topic:1`
 
-After this, normal traffic in all topics of that forum chat is forwarded.
+After this, normal group/topic traffic is forwarded.
 
 ## Useful tgcli commands
 


### PR DESCRIPTION
## Summary
Full msg-router data plane for WhatsApp shared-bot + Discord/TG migration support. Validated with end-to-end 3-stage migration rehearsal (Stage 0 standalone mux → Stage 1 nested → Stage 2 direct).

### WhatsApp
- P5 wiring: real Baileys session on msg-router shared bot, bridging ingress (messages.upsert → inbox) and egress (agent outbound → relayMessage)
- LID→phone JID preference in Noise emulator inbox pump
- Bundle seeding from stored tenant creds (agent skips prekey upload)
- Proactive outbound: per-JID synthetic prekey bundles via `resolveRecipientBundle`
- ED routing header parsing in Noise emulator (Baileys prepends when creds have `routingInfo`)

### Discord
- `GET /applications/@me` endpoint for discord.js v14.16+ startup probe
- `resume_gateway_url` fix in egress-ws READY payload
- Ingress auto-reconnect on WS close (exponential backoff, capped at 30s)
- Auto-mint per-tenant Discord cred during import-tenant

### Infrastructure
- Super-tenant fallback for nested mode (Stage 1 + Stage 2 agents coexist)
- Auto-register shared_bots row during import-tenant
- Rehearsal runbook with 20 documented pitfalls

### Submodule (openclaw → phala-2026.3.13)
- Per-account `wsUrl` for WhatsApp (mirrors TG/Discord `apiBaseUrl`)
- Per-account `apiBaseUrl` threading through Discord `fetchDiscordApplicationId`
- `markOnlineOnConnect: true` for linked-device visibility

## Test plan
- [x] All existing tests pass (36 Discord egress REST, 57 WA)
- [x] Full 3-stage migration rehearsal — TG, Discord, WA all verified end-to-end
- [x] Stage 1 + Stage 2 agents coexist via super-tenant fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)