### PR TITLE
Fix WhatsApp mux media sends using unbound derived session keys

### DIFF
--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -672,6 +672,17 @@ describe("runMessageAction outbound session key selection", () => {
     messageId: "wa-media",
     toJid: "15550001111@s.whatsapp.net",
   });
+  const activeSessionKey = "agent:main:whatsapp:direct:+15550001111";
+  const whatsappMainScopeCfg = {
+    session: {
+      dmScope: "main",
+    },
+    channels: {
+      whatsapp: {
+        allowFrom: ["*"],
+      },
+    },
+  } as OpenClawConfig;
 
   const whatsappOutboundPlugin = createOutboundTestPlugin({
     id: "whatsapp",
@@ -701,34 +712,35 @@ describe("runMessageAction outbound session key selection", () => {
     setActivePluginRegistry(createTestRegistry([]));
   });
 
-  it("keeps the active whatsapp session key when derived key collapses to main", async () => {
-    const cfg = {
-      session: {
-        dmScope: "main",
-      },
-      channels: {
-        whatsapp: {
-          allowFrom: ["*"],
-        },
-      },
-    } as OpenClawConfig;
-    const activeSessionKey = "agent:main:whatsapp:direct:+15550001111";
-
-    const result = await runMessageAction({
-      cfg,
+  async function runWhatsAppMediaSend(params: {
+    target: string;
+    message: string;
+    toolContext?: { currentChannelId: string; currentChannelProvider: "whatsapp" };
+  }) {
+    return await runMessageAction({
+      cfg: whatsappMainScopeCfg,
       action: "send",
       params: {
         channel: "whatsapp",
-        target: "+15550001111",
-        message: "file attached",
+        target: params.target,
+        message: params.message,
         media: "https://example.com/file.pdf",
       },
       sessionKey: activeSessionKey,
+      toolContext: params.toolContext,
       dryRun: false,
+    });
+  }
+
+  it("keeps the active whatsapp session key when derived key collapses to main", async () => {
+    const result = await runWhatsAppMediaSend({
+      target: "+15550001111",
+      message: "file attached",
     });
 
     expect(result.kind).toBe("send");
     expect(result.handledBy).toBe("core");
+    expect(sendMedia).toHaveBeenCalledTimes(1);
     expect(sendMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: activeSessionKey,
@@ -737,33 +749,13 @@ describe("runMessageAction outbound session key selection", () => {
   });
 
   it("does not reuse a whatsapp session key when sending to another target", async () => {
-    const cfg = {
-      session: {
-        dmScope: "main",
-      },
-      channels: {
-        whatsapp: {
-          allowFrom: ["*"],
-        },
-      },
-    } as OpenClawConfig;
-    const activeSessionKey = "agent:main:whatsapp:direct:+15550001111";
-
-    const result = await runMessageAction({
-      cfg,
-      action: "send",
-      params: {
-        channel: "whatsapp",
-        target: "+15550002222",
-        message: "cross context send",
-        media: "https://example.com/file.pdf",
-      },
-      sessionKey: activeSessionKey,
+    const result = await runWhatsAppMediaSend({
+      target: "+15550002222",
+      message: "cross context send",
       toolContext: {
         currentChannelId: "+15550001111",
         currentChannelProvider: "whatsapp",
       },
-      dryRun: false,
     });
 
     expect(result.kind).toBe("send");

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -661,6 +661,93 @@ describe("runMessageAction media caption behavior", () => {
   });
 });
 
+describe("runMessageAction outbound session key selection", () => {
+  const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+    jsonResult({
+      ok: true,
+      sessionKey: typeof params.__sessionKey === "string" ? params.__sessionKey : null,
+      agentId: typeof params.__agentId === "string" ? params.__agentId : null,
+    }),
+  );
+
+  const whatsappActionPlugin: ChannelPlugin = {
+    id: "whatsapp",
+    meta: {
+      id: "whatsapp",
+      label: "WhatsApp",
+      selectionLabel: "WhatsApp",
+      docsPath: "/channels/whatsapp",
+      blurb: "WhatsApp action probe.",
+    },
+    capabilities: { chatTypes: ["direct", "group"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isConfigured: () => true,
+    },
+    actions: {
+      listActions: () => ["send"],
+      supportsAction: ({ action }) => action === "send",
+      handleAction,
+    },
+  };
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: whatsappActionPlugin,
+        },
+      ]),
+    );
+    handleAction.mockClear();
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("keeps the active session key for whatsapp media sends", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+    const activeSessionKey = "agent:main:whatsapp:direct:+15550001111";
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: {
+        channel: "whatsapp",
+        target: "+15550001111",
+        message: "file attached",
+        media: "https://example.com/file.pdf",
+      },
+      sessionKey: activeSessionKey,
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.handledBy).toBe("plugin");
+    expect(handleAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          __sessionKey: activeSessionKey,
+        }),
+      }),
+    );
+    const called = handleAction.mock.calls[0]?.[0] as
+      | { params?: Record<string, unknown> }
+      | undefined;
+    expect(called?.params?.__sessionKey).not.toBe("agent:main:main");
+  });
+});
+
 describe("runMessageAction card-only send behavior", () => {
   const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
     jsonResult({

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -662,35 +662,26 @@ describe("runMessageAction media caption behavior", () => {
 });
 
 describe("runMessageAction outbound session key selection", () => {
-  const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
-    jsonResult({
-      ok: true,
-      sessionKey: typeof params.__sessionKey === "string" ? params.__sessionKey : null,
-      agentId: typeof params.__agentId === "string" ? params.__agentId : null,
-    }),
-  );
+  const sendText = vi.fn().mockResolvedValue({
+    channel: "whatsapp",
+    messageId: "wa-text",
+    toJid: "15550001111@s.whatsapp.net",
+  });
+  const sendMedia = vi.fn().mockResolvedValue({
+    channel: "whatsapp",
+    messageId: "wa-media",
+    toJid: "15550001111@s.whatsapp.net",
+  });
 
-  const whatsappActionPlugin: ChannelPlugin = {
+  const whatsappOutboundPlugin = createOutboundTestPlugin({
     id: "whatsapp",
-    meta: {
-      id: "whatsapp",
-      label: "WhatsApp",
-      selectionLabel: "WhatsApp",
-      docsPath: "/channels/whatsapp",
-      blurb: "WhatsApp action probe.",
-    },
     capabilities: { chatTypes: ["direct", "group"] },
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: () => ({ enabled: true }),
-      isConfigured: () => true,
+    outbound: {
+      deliveryMode: "direct",
+      sendText,
+      sendMedia,
     },
-    actions: {
-      listActions: () => ["send"],
-      supportsAction: ({ action }) => action === "send",
-      handleAction,
-    },
-  };
+  });
 
   beforeEach(() => {
     setActivePluginRegistry(
@@ -698,19 +689,23 @@ describe("runMessageAction outbound session key selection", () => {
         {
           pluginId: "whatsapp",
           source: "test",
-          plugin: whatsappActionPlugin,
+          plugin: whatsappOutboundPlugin,
         },
       ]),
     );
-    handleAction.mockClear();
+    sendText.mockClear();
+    sendMedia.mockClear();
   });
 
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry([]));
   });
 
-  it("keeps the active session key for whatsapp media sends", async () => {
+  it("keeps the active whatsapp session key when derived key collapses to main", async () => {
     const cfg = {
+      session: {
+        dmScope: "main",
+      },
       channels: {
         whatsapp: {
           allowFrom: ["*"],
@@ -733,18 +728,51 @@ describe("runMessageAction outbound session key selection", () => {
     });
 
     expect(result.kind).toBe("send");
-    expect(result.handledBy).toBe("plugin");
-    expect(handleAction).toHaveBeenCalledWith(
+    expect(result.handledBy).toBe("core");
+    expect(sendMedia).toHaveBeenCalledWith(
       expect.objectContaining({
-        params: expect.objectContaining({
-          __sessionKey: activeSessionKey,
-        }),
+        sessionKey: activeSessionKey,
       }),
     );
-    const called = handleAction.mock.calls[0]?.[0] as
-      | { params?: Record<string, unknown> }
-      | undefined;
-    expect(called?.params?.__sessionKey).not.toBe("agent:main:main");
+  });
+
+  it("does not reuse a whatsapp session key when sending to another target", async () => {
+    const cfg = {
+      session: {
+        dmScope: "main",
+      },
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+    const activeSessionKey = "agent:main:whatsapp:direct:+15550001111";
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: {
+        channel: "whatsapp",
+        target: "+15550002222",
+        message: "cross context send",
+        media: "https://example.com/file.pdf",
+      },
+      sessionKey: activeSessionKey,
+      toolContext: {
+        currentChannelId: "+15550001111",
+        currentChannelProvider: "whatsapp",
+      },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.handledBy).toBe("core");
+    expect(sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
   });
 });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -481,8 +481,12 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     toolContext: input.toolContext,
     allowSlackAutoThread: channel === "slack" && !replyToId,
   });
+  const providedSessionKey =
+    typeof input.sessionKey === "string" && input.sessionKey.trim().length > 0
+      ? input.sessionKey.trim().toLowerCase()
+      : undefined;
   const outboundRoute =
-    agentId && !dryRun
+    agentId && !dryRun && !providedSessionKey
       ? await resolveOutboundSessionRoute({
           cfg,
           channel,
@@ -503,8 +507,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       route: outboundRoute,
     });
   }
-  if (outboundRoute && !dryRun) {
-    params.__sessionKey = outboundRoute.sessionKey;
+  const outboundSessionKey = providedSessionKey ?? outboundRoute?.sessionKey;
+  if (outboundSessionKey && !dryRun) {
+    params.__sessionKey = outboundSessionKey;
   }
   if (agentId) {
     params.__agentId = agentId;
@@ -519,15 +524,15 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       params,
       agentId,
       accountId: accountId ?? undefined,
-      sessionKey: input.sessionKey,
+      sessionKey: providedSessionKey ?? input.sessionKey,
       gateway,
       toolContext: input.toolContext,
       deps: input.deps,
       dryRun,
       mirror:
-        outboundRoute && !dryRun
+        outboundSessionKey && !dryRun
           ? {
-              sessionKey: outboundRoute.sessionKey,
+              sessionKey: outboundSessionKey,
               agentId,
               text: message,
               mediaUrls: mirrorMediaUrls,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -13,12 +13,14 @@ import type {
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { buildAgentMainSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../utils/message-channel.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
@@ -86,6 +88,107 @@ function resolveAndApplyOutboundThreadId(
     params.threadId = resolved;
   }
   return resolved ?? undefined;
+}
+
+function normalizeProvidedSessionKey(sessionKey?: string): string | undefined {
+  const trimmed = typeof sessionKey === "string" ? sessionKey.trim() : "";
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function parseWhatsAppTargetFromSessionKey(sessionKey: string): string | undefined {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return undefined;
+  }
+  const parts = parsed.rest
+    .split(":")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length < 3) {
+    return undefined;
+  }
+  if (parts[0]?.toLowerCase() !== "whatsapp") {
+    return undefined;
+  }
+
+  const second = parts[1]?.toLowerCase();
+  const third = parts[2]?.toLowerCase();
+  let kind: "direct" | "group" | undefined;
+  let peerStart = 0;
+  if (second === "direct" || second === "group") {
+    kind = second;
+    peerStart = 2;
+  } else if (third === "direct" || third === "group") {
+    kind = third;
+    peerStart = 3;
+  } else {
+    return undefined;
+  }
+
+  const peerId = parts.slice(peerStart).join(":").trim();
+  if (!peerId) {
+    return undefined;
+  }
+  const normalizedTarget = normalizeWhatsAppTarget(peerId);
+  if (!normalizedTarget) {
+    return undefined;
+  }
+  const isGroup = isWhatsAppGroupJid(normalizedTarget);
+  if ((kind === "group" && !isGroup) || (kind === "direct" && isGroup)) {
+    return undefined;
+  }
+  return normalizedTarget;
+}
+
+function shouldPreserveWhatsAppSessionKey(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  target: string;
+  providedSessionKey: string;
+  derivedSessionKey?: string;
+}): boolean {
+  if (!params.derivedSessionKey || !params.agentId) {
+    return false;
+  }
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: params.cfg.session?.mainKey,
+  });
+  if (params.derivedSessionKey !== mainSessionKey) {
+    return false;
+  }
+  const providedTarget = parseWhatsAppTargetFromSessionKey(params.providedSessionKey);
+  const outboundTarget = normalizeWhatsAppTarget(params.target);
+  return Boolean(providedTarget && outboundTarget && providedTarget === outboundTarget);
+}
+
+function selectOutboundSessionKey(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  target: string;
+  agentId?: string;
+  providedSessionKey?: string;
+  derivedSessionKey?: string;
+}): string | undefined {
+  if (!params.derivedSessionKey) {
+    return params.providedSessionKey;
+  }
+  if (!params.providedSessionKey) {
+    return params.derivedSessionKey;
+  }
+  if (
+    params.channel === "whatsapp" &&
+    shouldPreserveWhatsAppSessionKey({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      target: params.target,
+      providedSessionKey: params.providedSessionKey,
+      derivedSessionKey: params.derivedSessionKey,
+    })
+  ) {
+    return params.providedSessionKey;
+  }
+  return params.derivedSessionKey;
 }
 
 export type RunMessageActionParams = {
@@ -481,13 +584,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     toolContext: input.toolContext,
     allowSlackAutoThread: channel === "slack" && !replyToId,
   });
-  const providedSessionKey =
-    typeof input.sessionKey === "string" && input.sessionKey.trim().length > 0
-      ? input.sessionKey.trim().toLowerCase()
-      : undefined;
-  const preserveProvidedSessionKey = channel === "whatsapp" && Boolean(providedSessionKey);
+  const providedSessionKey = normalizeProvidedSessionKey(input.sessionKey);
   const outboundRoute =
-    agentId && !dryRun && !preserveProvidedSessionKey
+    agentId && !dryRun
       ? await resolveOutboundSessionRoute({
           cfg,
           channel,
@@ -499,7 +598,15 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
           threadId: resolvedThreadId,
         })
       : null;
-  if (outboundRoute && agentId && !dryRun) {
+  const outboundSessionKey = selectOutboundSessionKey({
+    cfg,
+    channel,
+    target: to,
+    agentId,
+    providedSessionKey,
+    derivedSessionKey: outboundRoute?.sessionKey,
+  });
+  if (outboundRoute && agentId && !dryRun && outboundSessionKey === outboundRoute.sessionKey) {
     await ensureOutboundSessionEntry({
       cfg,
       agentId,
@@ -508,8 +615,6 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       route: outboundRoute,
     });
   }
-  const outboundSessionKey =
-    (preserveProvidedSessionKey ? providedSessionKey : undefined) ?? outboundRoute?.sessionKey;
   if (outboundSessionKey && !dryRun) {
     params.__sessionKey = outboundSessionKey;
   }
@@ -526,7 +631,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       params,
       agentId,
       accountId: accountId ?? undefined,
-      sessionKey: input.sessionKey,
+      sessionKey:
+        channel === "whatsapp" ? (outboundSessionKey ?? input.sessionKey) : input.sessionKey,
       gateway,
       toolContext: input.toolContext,
       deps: input.deps,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -485,8 +485,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     typeof input.sessionKey === "string" && input.sessionKey.trim().length > 0
       ? input.sessionKey.trim().toLowerCase()
       : undefined;
+  const preserveProvidedSessionKey = channel === "whatsapp" && Boolean(providedSessionKey);
   const outboundRoute =
-    agentId && !dryRun && !providedSessionKey
+    agentId && !dryRun && !preserveProvidedSessionKey
       ? await resolveOutboundSessionRoute({
           cfg,
           channel,
@@ -507,7 +508,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       route: outboundRoute,
     });
   }
-  const outboundSessionKey = providedSessionKey ?? outboundRoute?.sessionKey;
+  const outboundSessionKey =
+    (preserveProvidedSessionKey ? providedSessionKey : undefined) ?? outboundRoute?.sessionKey;
   if (outboundSessionKey && !dryRun) {
     params.__sessionKey = outboundSessionKey;
   }
@@ -524,7 +526,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       params,
       agentId,
       accountId: accountId ?? undefined,
-      sessionKey: providedSessionKey ?? input.sessionKey,
+      sessionKey: input.sessionKey,
       gateway,
       toolContext: input.toolContext,
       deps: input.deps,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -95,100 +95,56 @@ function normalizeProvidedSessionKey(sessionKey?: string): string | undefined {
   return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
-function parseWhatsAppTargetFromSessionKey(sessionKey: string): string | undefined {
+function parseWhatsAppSessionTarget(
+  sessionKey: string,
+): { kind: "direct" | "group"; target: string } | null {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
-    return undefined;
+    return null;
   }
-  const parts = parsed.rest
-    .split(":")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length < 3) {
-    return undefined;
+  // Supports both:
+  // - agent:<id>:whatsapp:direct:<peer>
+  // - agent:<id>:whatsapp:<account>:direct:<peer>
+  const match = /^whatsapp:(?:[^:]+:)?(direct|group):(.+)$/i.exec(parsed.rest);
+  if (!match) {
+    return null;
   }
-  if (parts[0]?.toLowerCase() !== "whatsapp") {
-    return undefined;
-  }
-
-  const second = parts[1]?.toLowerCase();
-  const third = parts[2]?.toLowerCase();
-  let kind: "direct" | "group" | undefined;
-  let peerStart = 0;
-  if (second === "direct" || second === "group") {
-    kind = second;
-    peerStart = 2;
-  } else if (third === "direct" || third === "group") {
-    kind = third;
-    peerStart = 3;
-  } else {
-    return undefined;
-  }
-
-  const peerId = parts.slice(peerStart).join(":").trim();
-  if (!peerId) {
-    return undefined;
-  }
+  const kind = match[1]?.toLowerCase() as "direct" | "group";
+  const peerId = match[2]?.trim() ?? "";
   const normalizedTarget = normalizeWhatsAppTarget(peerId);
   if (!normalizedTarget) {
-    return undefined;
+    return null;
   }
   const isGroup = isWhatsAppGroupJid(normalizedTarget);
   if ((kind === "group" && !isGroup) || (kind === "direct" && isGroup)) {
-    return undefined;
+    return null;
   }
-  return normalizedTarget;
+  return { kind, target: normalizedTarget };
 }
 
-function shouldPreserveWhatsAppSessionKey(params: {
+function resolveWhatsAppSendSessionKey(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   target: string;
   providedSessionKey: string;
   derivedSessionKey?: string;
-}): boolean {
+}): string | undefined {
   if (!params.derivedSessionKey || !params.agentId) {
-    return false;
+    return params.derivedSessionKey;
   }
   const mainSessionKey = buildAgentMainSessionKey({
     agentId: params.agentId,
     mainKey: params.cfg.session?.mainKey,
   });
   if (params.derivedSessionKey !== mainSessionKey) {
-    return false;
-  }
-  const providedTarget = parseWhatsAppTargetFromSessionKey(params.providedSessionKey);
-  const outboundTarget = normalizeWhatsAppTarget(params.target);
-  return Boolean(providedTarget && outboundTarget && providedTarget === outboundTarget);
-}
-
-function selectOutboundSessionKey(params: {
-  cfg: OpenClawConfig;
-  channel: ChannelId;
-  target: string;
-  agentId?: string;
-  providedSessionKey?: string;
-  derivedSessionKey?: string;
-}): string | undefined {
-  if (!params.derivedSessionKey) {
-    return params.providedSessionKey;
-  }
-  if (!params.providedSessionKey) {
     return params.derivedSessionKey;
   }
-  if (
-    params.channel === "whatsapp" &&
-    shouldPreserveWhatsAppSessionKey({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      target: params.target,
-      providedSessionKey: params.providedSessionKey,
-      derivedSessionKey: params.derivedSessionKey,
-    })
-  ) {
-    return params.providedSessionKey;
+  const providedTarget = parseWhatsAppSessionTarget(params.providedSessionKey);
+  const outboundTarget = normalizeWhatsAppTarget(params.target);
+  if (!providedTarget || !outboundTarget || providedTarget.target !== outboundTarget) {
+    return params.derivedSessionKey;
   }
-  return params.derivedSessionKey;
+  return params.providedSessionKey;
 }
 
 export type RunMessageActionParams = {
@@ -598,15 +554,20 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
           threadId: resolvedThreadId,
         })
       : null;
-  const outboundSessionKey = selectOutboundSessionKey({
-    cfg,
-    channel,
-    target: to,
-    agentId,
-    providedSessionKey,
-    derivedSessionKey: outboundRoute?.sessionKey,
-  });
-  if (outboundRoute && agentId && !dryRun && outboundSessionKey === outboundRoute.sessionKey) {
+  const derivedSessionKey = outboundRoute?.sessionKey;
+  const selectedRouteSessionKey =
+    channel === "whatsapp" && providedSessionKey
+      ? resolveWhatsAppSendSessionKey({
+          cfg,
+          agentId,
+          target: to,
+          providedSessionKey,
+          derivedSessionKey,
+        })
+      : derivedSessionKey;
+  const transportSessionKey =
+    channel === "whatsapp" ? (selectedRouteSessionKey ?? input.sessionKey) : input.sessionKey;
+  if (outboundRoute && agentId && !dryRun && selectedRouteSessionKey === derivedSessionKey) {
     await ensureOutboundSessionEntry({
       cfg,
       agentId,
@@ -615,8 +576,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       route: outboundRoute,
     });
   }
-  if (outboundSessionKey && !dryRun) {
-    params.__sessionKey = outboundSessionKey;
+  if (selectedRouteSessionKey && !dryRun) {
+    params.__sessionKey = selectedRouteSessionKey;
   }
   if (agentId) {
     params.__agentId = agentId;
@@ -631,16 +592,15 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       params,
       agentId,
       accountId: accountId ?? undefined,
-      sessionKey:
-        channel === "whatsapp" ? (outboundSessionKey ?? input.sessionKey) : input.sessionKey,
+      sessionKey: transportSessionKey,
       gateway,
       toolContext: input.toolContext,
       deps: input.deps,
       dryRun,
       mirror:
-        outboundSessionKey && !dryRun
+        selectedRouteSessionKey && !dryRun
           ? {
-              sessionKey: outboundSessionKey,
+              sessionKey: selectedRouteSessionKey,
               agentId,
               text: message,
               mediaUrls: mirrorMediaUrls,


### PR DESCRIPTION
## Summary
- keep the active message action `sessionKey` when present instead of always deriving a new outbound route key
- only derive and persist an outbound session route when no session key was provided
- apply the same selected session key to `__sessionKey`, send context, and mirror context

## Why
WhatsApp mux outbound sends can fail with:
`mux outbound failed (403): route not bound`

This happens when an existing bound session key (for example `agent:main:whatsapp:direct:+1555...`) gets replaced by a derived key like `agent:main:main` during send action handling, especially on media sends.

## Testing
- `pnpm test src/infra/outbound/message-action-runner.test.ts`
- `pnpm test src/infra/outbound/message-action-runner.threading.test.ts`

Fixes #13
