### PR TITLE
CI: fix oxfmt check failures

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -296,7 +296,17 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent, sessionKey }) => {
+    sendText: async ({
+      cfg,
+      to,
+      text,
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      silent,
+      sessionKey,
+    }) => {
       if (isMuxEnabled({ cfg, channel: "discord", accountId: accountId ?? undefined })) {
         const result = await sendViaMux({
           cfg,

--- a/phala-deploy/gogcli/README.md
+++ b/phala-deploy/gogcli/README.md
@@ -41,9 +41,9 @@ gog --help                  # full command reference
 
 ## Build details
 
-| Detail | Value |
-|--------|-------|
-| Source | `github.com/Leechael/gogcli` branch `feat/env-token-injection` |
-| Build | `CGO_ENABLED=0`, stripped (`-s -w`) |
-| Binary size | ~21MB |
-| Linked | Static (no libc dependency) |
+| Detail      | Value                                                          |
+| ----------- | -------------------------------------------------------------- |
+| Source      | `github.com/Leechael/gogcli` branch `feat/env-token-injection` |
+| Build       | `CGO_ENABLED=0`, stripped (`-s -w`)                            |
+| Binary size | ~21MB                                                          |
+| Linked      | Static (no libc dependency)                                    |

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,6 +1,6 @@
 import { sendMessageDiscord, sendPollDiscord } from "../../../discord/send.js";
-import { normalizeDiscordOutboundTarget } from "../normalize/discord.js";
 import { buildDiscordRawSend } from "../mux-envelope.js";
+import { normalizeDiscordOutboundTarget } from "../normalize/discord.js";
 import type { ChannelOutboundAdapter } from "../types.js";
 import { isMuxEnabled, sendViaMux } from "./mux.js";
 
@@ -38,7 +38,18 @@ export const discordOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId, silent, sessionKey }) => {
+  sendMedia: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    accountId,
+    deps,
+    replyToId,
+    silent,
+    sessionKey,
+  }) => {
     if (isMuxEnabled({ cfg, channel: "discord", accountId: accountId ?? undefined })) {
       const result = await sendViaMux({
         cfg,

--- a/src/channels/plugins/outbound/mux.ts
+++ b/src/channels/plugins/outbound/mux.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../../../config/config.js";
-import type { PollInput } from "../../../polls.js";
 import { loadOrCreateDeviceIdentity } from "../../../infra/device-identity.js";
+import type { PollInput } from "../../../polls.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../routing/session-key.js";
 
 type SupportedMuxChannel = "whatsapp" | "telegram" | "discord";

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -2,8 +2,8 @@ import { chunkText } from "../../../auto-reply/chunk.js";
 import { shouldLogVerbose } from "../../../globals.js";
 import { sendPollWhatsApp } from "../../../web/outbound.js";
 import { resolveWhatsAppOutboundTarget } from "../../../whatsapp/resolve-outbound-target.js";
-import type { ChannelOutboundAdapter } from "../types.js";
 import { buildWhatsAppRawSend } from "../mux-envelope.js";
+import type { ChannelOutboundAdapter } from "../types.js";
 import { isMuxEnabled, sendViaMux } from "./mux.js";
 
 export const whatsappOutbound: ChannelOutboundAdapter = {
@@ -41,7 +41,17 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback, sessionKey }) => {
+  sendMedia: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    accountId,
+    deps,
+    gifPlayback,
+    sessionKey,
+  }) => {
     if (isMuxEnabled({ cfg, channel: "whatsapp", accountId: accountId ?? undefined })) {
       const result = await sendViaMux({
         cfg,

--- a/src/telegram/callback-actions.ts
+++ b/src/telegram/callback-actions.ts
@@ -1,10 +1,10 @@
-import type { OpenClawConfig } from "../config/config.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
 import { buildModelsProviderData } from "../auto-reply/reply/commands-models.js";
 import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";


### PR DESCRIPTION
## Summary
- apply `oxfmt` formatting fixes for files reported by the failing `check` job
- keep the change scoped to formatting-only updates

## Validation
- `pnpm format:check`
