### PR TITLE
Fix TypeScript check regressions in mux and onboarding tests

### DIFF
--- a/extensions/discord/src/mux-sendpayload.test.ts
+++ b/extensions/discord/src/mux-sendpayload.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 
 describe("discord extension mux outbound sendPayload", () => {
   it("passes channelData through mux", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -102,7 +102,11 @@ describe("discord extension mux outbound sendPayload", () => {
 
     expect(result).toMatchObject({ channel: "discord", messageId: "mx-discord-1" });
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    const [, init] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    const init = fetchSpy.mock.calls[1]?.[1];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("expected request init in mux send call");
+    }
     const body = JSON.parse(String(init.body)) as {
       channel?: string;
       sessionKey?: string;

--- a/extensions/whatsapp/src/mux-sendpayload.test.ts
+++ b/extensions/whatsapp/src/mux-sendpayload.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 
 describe("whatsapp extension mux outbound sendPayload", () => {
   it("passes channelData and mediaUrls through mux", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -104,7 +104,11 @@ describe("whatsapp extension mux outbound sendPayload", () => {
     expect(result).toMatchObject({ channel: "whatsapp", messageId: "mx-wa-1" });
     // register call + single send (mediaUrls passed as array) = 2 calls
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    const [, init] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    const init = fetchSpy.mock.calls[1]?.[1];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("expected request init in mux send call");
+    }
     const body = JSON.parse(String(init.body)) as {
       channel?: string;
       sessionKey?: string;

--- a/src/agents/models-config.providers.codex.test.ts
+++ b/src/agents/models-config.providers.codex.test.ts
@@ -2,14 +2,15 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { normalizeProviders } from "./models-config.providers.js";
 
-function makeModel(id: string) {
+function makeModel(id: string): ModelDefinitionConfig {
   return {
     id,
     name: id,
     reasoning: true,
-    input: ["text"] as const,
+    input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
     maxTokens: 8192,

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -23,7 +23,7 @@ const subagentRegistryMock = {
   countActiveDescendantRuns: vi.fn((_sessionKey: string) => 0),
   resolveRequesterForChildSession: vi.fn((_sessionKey: string): RequesterResolution => null),
 };
-const chatHistoryMock = vi.fn(async (_sessionKey: string) => ({ messages: [] as Array<unknown> }));
+const chatHistoryMock = vi.fn(async (_sessionKey?: string) => ({ messages: [] as Array<unknown> }));
 let sessionStore: Record<string, Record<string, unknown>> = {};
 let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
   session: {

--- a/src/channels/plugins/outbound/mux-routing.test.ts
+++ b/src/channels/plugins/outbound/mux-routing.test.ts
@@ -110,7 +110,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes discord outbound through mux when enabled", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -158,7 +158,13 @@ describe("mux outbound routing", () => {
       ([callInput]) => resolveFetchUrl(callInput) === "http://mux.local/v1/mux/outbound/send",
     );
     expect(sendCall).toBeDefined();
-    const [url, init] = sendCall as [string | URL | Request, RequestInit];
+    const url = sendCall?.[0];
+    const init = sendCall?.[1];
+    expect(url).toBeDefined();
+    expect(init).toBeDefined();
+    if (url === undefined || init === undefined) {
+      throw new Error("expected mux outbound send call with RequestInit");
+    }
     expect(resolveFetchUrl(url)).toBe("http://mux.local/v1/mux/outbound/send");
     expect(parseJsonRequestBody(init)).toMatchObject({
       channel: "discord",
@@ -175,7 +181,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes whatsapp outbound through mux when enabled", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -219,7 +225,13 @@ describe("mux outbound routing", () => {
       ([callInput]) => resolveFetchUrl(callInput) === "http://mux.local/v1/mux/outbound/send",
     );
     expect(sendCall).toBeDefined();
-    const [url, init] = sendCall as [string | URL | Request, RequestInit];
+    const url = sendCall?.[0];
+    const init = sendCall?.[1];
+    expect(url).toBeDefined();
+    expect(init).toBeDefined();
+    if (url === undefined || init === undefined) {
+      throw new Error("expected mux outbound send call with RequestInit");
+    }
     expect(resolveFetchUrl(url)).toBe("http://mux.local/v1/mux/outbound/send");
     expect(parseJsonRequestBody(init)).toMatchObject({
       channel: "whatsapp",
@@ -236,7 +248,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes telegram outbound through mux from default account config", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -278,7 +290,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes discord outbound through mux from default account config", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -320,7 +332,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes whatsapp outbound through mux from default account config", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -362,7 +374,7 @@ describe("mux outbound routing", () => {
   });
 
   it("routes typing through mux when enabled", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -400,7 +412,13 @@ describe("mux outbound routing", () => {
       ([callInput]) => resolveFetchUrl(callInput) === "http://mux.local/v1/mux/outbound/send",
     );
     expect(sendCall).toBeDefined();
-    const [url, init] = sendCall as [string | URL | Request, RequestInit];
+    const url = sendCall?.[0];
+    const init = sendCall?.[1];
+    expect(url).toBeDefined();
+    expect(init).toBeDefined();
+    if (url === undefined || init === undefined) {
+      throw new Error("expected mux outbound send call with RequestInit");
+    }
     expect(resolveFetchUrl(url)).toBe("http://mux.local/v1/mux/outbound/send");
     expect(parseJsonRequestBody(init)).toMatchObject({
       op: "action",
@@ -471,7 +489,7 @@ describe("mux outbound routing", () => {
   });
 
   it("rejects telegram mux success payload missing messageId", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -509,7 +527,7 @@ describe("mux outbound routing", () => {
   });
 
   it("rejects discord mux success payload missing messageId", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({
@@ -547,7 +565,7 @@ describe("mux outbound routing", () => {
   });
 
   it("rejects whatsapp mux success payload missing messageId", async () => {
-    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url === "http://mux.local/v1/instances/register") {
         return jsonResponse({

--- a/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice-inference.ts
@@ -21,6 +21,7 @@ type AuthChoiceFlagOptions = Pick<
   | "veniceApiKey"
   | "togetherApiKey"
   | "huggingfaceApiKey"
+  | "redpillApiKey"
   | "zaiApiKey"
   | "xiaomiApiKey"
   | "minimaxApiKey"

--- a/src/gateway/mux-http.test.ts
+++ b/src/gateway/mux-http.test.ts
@@ -10,11 +10,11 @@ const OPENCLAW_ID = "openclaw-rt-1";
 
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
-  dispatchInboundMessage: vi.fn(async () => ({
+  dispatchInboundMessage: vi.fn(async (_params?: unknown) => ({
     queuedFinal: false,
     counts: { tool: 0, block: 0, final: 0 },
   })),
-  dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => ({
+  dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (_params?: unknown) => ({
     queuedFinal: false,
     counts: { tool: 0, block: 0, final: 0 },
   })),
@@ -592,8 +592,13 @@ describe("handleMuxInboundHttpRequest", () => {
           },
         },
       });
-      mocks.dispatchInboundMessage.mockImplementationOnce(async (params) => {
-        await params.replyOptions?.onReplyStart?.();
+      mocks.dispatchInboundMessage.mockImplementationOnce(async (params?: unknown) => {
+        const typedParams = params as
+          | {
+              replyOptions?: { onReplyStart?: () => Promise<void> | void };
+            }
+          | undefined;
+        await typedParams?.replyOptions?.onReplyStart?.();
         return {
           queuedFinal: false,
           counts: { tool: 0, block: 0, final: 0 },


### PR DESCRIPTION
## Summary
- fix fetch mock tuple typing in mux outbound tests (core + discord/whatsapp extensions)
- align codex provider test fixture model typing with `ModelDefinitionConfig`
- allow optional session key in subagent announce format test mock
- include `redpillApiKey` in non-interactive auth-choice inference option typing
- update mux HTTP dispatcher mocks to accept params so stricter tuple indexing checks pass

## Validation
- pnpm check
