### PR TITLE
fix(mux-proxy): base64-encode htpasswd to avoid shell interpolation

### DIFF
--- a/mux-server/deploy/docker-compose.yml
+++ b/mux-server/deploy/docker-compose.yml
@@ -50,7 +50,12 @@ services:
     configs:
       - source: mux_proxy_nginx_conf
         target: /etc/nginx/nginx.conf
-    entrypoint: ["sh", "-c", "printf '%s\\n' \"$MUX_PROXY_PROMETHEUS_HTPASSWD_B64\" | base64 -d > /etc/nginx/htpasswd-prometheus && exec nginx -g 'daemon off;'"]
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "printf '%s\\n' \"$MUX_PROXY_PROMETHEUS_HTPASSWD_B64\" | base64 -d > /etc/nginx/htpasswd-prometheus && exec nginx -g 'daemon off;'",
+      ]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:18891/health >/dev/null || exit 1"]

--- a/mux-server/deploy/docker-compose.yml
+++ b/mux-server/deploy/docker-compose.yml
@@ -45,11 +45,12 @@ services:
         condition: service_healthy
     ports:
       - "18891:18891"
+    environment:
+      MUX_PROXY_PROMETHEUS_HTPASSWD_B64: ${MUX_PROXY_PROMETHEUS_HTPASSWD_B64:?set MUX_PROXY_PROMETHEUS_HTPASSWD_B64}
     configs:
       - source: mux_proxy_nginx_conf
         target: /etc/nginx/nginx.conf
-      - source: mux_proxy_htpasswd_prometheus
-        target: /etc/nginx/htpasswd-prometheus
+    entrypoint: ["sh", "-c", "printf '%s\\n' \"$MUX_PROXY_PROMETHEUS_HTPASSWD_B64\" | base64 -d > /etc/nginx/htpasswd-prometheus && exec nginx -g 'daemon off;'"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:18891/health >/dev/null || exit 1"]
@@ -116,6 +117,3 @@ configs:
           }
         }
       }
-  mux_proxy_htpasswd_prometheus:
-    content: |
-      prometheus:${MUX_PROXY_PROMETHEUS_PASSWORD_HASH:?set MUX_PROXY_PROMETHEUS_PASSWORD_HASH}


### PR DESCRIPTION
## Summary
- The nginx proxy's prometheus htpasswd config used inline `${MUX_PROXY_PROMETHEUS_PASSWORD_HASH}` in a docker-compose `configs` block. The `$` characters in APR1/bcrypt hashes get interpreted as shell variables by docker-compose and `.env` parsers, producing broken htpasswd files.
- Replace with `MUX_PROXY_PROMETHEUS_HTPASSWD_B64` — a base64-encoded full htpasswd line (e.g. `prometheus:$2y$05$...`), decoded at container startup via entrypoint. Base64 is shell-safe across all `.env` consumers.

### Generate the value
```bash
htpasswd -nbB prometheus '<password>' | tr -d '\n' | base64 -w0
```

## Test plan
- [x] Verified on host: nginx `auth_basic` + `proxy_pass` with bcrypt htpasswd
- [x] Verified in Docker: `nginx:1.27-alpine` with base64-decoded htpasswd via entrypoint
- [x] Confirmed: no auth → 401, wrong password → 401, correct password → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)