### PR TITLE
fix: file watchers miss directories created after startup

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -2,10 +2,18 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-const watchMock = vi.fn(() => ({
-  on: vi.fn(),
-  close: vi.fn(async () => undefined),
-}));
+type WatcherHandler = (p: string) => void;
+
+const watchMock = vi.fn(() => {
+  const handlers = new Map<string, WatcherHandler>();
+  return {
+    on: vi.fn((event: string, handler: WatcherHandler) => {
+      handlers.set(event, handler);
+    }),
+    close: vi.fn(async () => undefined),
+    _handlers: handlers,
+  };
+});
 
 vi.mock("chokidar", () => {
   return {
@@ -14,30 +22,36 @@ vi.mock("chokidar", () => {
 });
 
 describe("ensureSkillsWatcher", () => {
-  it("ignores node_modules, dist, .git, and Python venvs by default", async () => {
+  it("watches skill root directories directly (not globs) and ignores common dirs", async () => {
     const mod = await import("./refresh.js");
     mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown; depth?: number }]>
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
-    expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
-    const posix = (p: string) => p.replaceAll("\\", "/");
+    // Should watch root directories directly, not glob patterns
+    for (const target of targets) {
+      expect(target).not.toContain("*");
+      expect(target).not.toContain("SKILL.md");
+    }
+
+    // Should include the expected skill root directories
     expect(targets).toEqual(
       expect.arrayContaining([
-        posix(path.join("/tmp/workspace", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", "skills", "*", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "*", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "*", "SKILL.md")),
+        path.join("/tmp/workspace", "skills"),
+        path.join("/tmp/workspace", ".agents", "skills"),
+        path.join(os.homedir(), ".agents", "skills"),
       ]),
     );
-    expect(targets.every((target) => target.includes("SKILL.md"))).toBe(true);
+
+    expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
+    // Depth should be limited to avoid deep traversal
+    expect(opts.depth).toBe(1);
+
     const ignored = mod.DEFAULT_SKILLS_WATCH_IGNORED;
 
     // Node/JS paths
@@ -69,5 +83,68 @@ describe("ensureSkillsWatcher", () => {
     // Should NOT ignore normal skill files
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
+  });
+});
+
+describe("isSkillPath", () => {
+  it("accepts SKILL.md at root of a watch root", async () => {
+    const { isSkillPath } = await import("./refresh.js");
+    const roots = ["/workspace/skills", "/home/.agents/skills"];
+
+    expect(isSkillPath("/workspace/skills/SKILL.md", roots)).toBe(true);
+    expect(isSkillPath("/home/.agents/skills/SKILL.md", roots)).toBe(true);
+  });
+
+  it("accepts SKILL.md one level deep (standard layout)", async () => {
+    const { isSkillPath } = await import("./refresh.js");
+    const roots = ["/workspace/skills"];
+
+    expect(isSkillPath("/workspace/skills/my-skill/SKILL.md", roots)).toBe(true);
+  });
+
+  it("rejects SKILL.md more than one level deep", async () => {
+    const { isSkillPath } = await import("./refresh.js");
+    const roots = ["/workspace/skills"];
+
+    expect(isSkillPath("/workspace/skills/a/b/SKILL.md", roots)).toBe(false);
+  });
+
+  it("rejects non-SKILL.md files", async () => {
+    const { isSkillPath } = await import("./refresh.js");
+    const roots = ["/workspace/skills"];
+
+    expect(isSkillPath("/workspace/skills/README.md", roots)).toBe(false);
+    expect(isSkillPath("/workspace/skills/my-skill/index.ts", roots)).toBe(false);
+  });
+
+  it("rejects paths outside any watch root", async () => {
+    const { isSkillPath } = await import("./refresh.js");
+    const roots = ["/workspace/skills"];
+
+    expect(isSkillPath("/other/skills/SKILL.md", roots)).toBe(false);
+  });
+
+  it("schedule handler ignores non-SKILL.md events", async () => {
+    const mod = await import("./refresh.js");
+    // Reset watcher from previous test
+    watchMock.mockClear();
+    mod.ensureSkillsWatcher({ workspaceDir: "/tmp/ws-filter-test" });
+
+    const mockWatcher = watchMock.mock.results[0]?.value as {
+      _handlers: Map<string, WatcherHandler>;
+    };
+    const addHandler = mockWatcher._handlers.get("add");
+    if (!addHandler) {
+      throw new Error("add handler not registered");
+    }
+
+    const versionBefore = mod.getSkillsSnapshotVersion("/tmp/ws-filter-test");
+
+    // Non-SKILL.md file should be filtered out — no version bump
+    addHandler(path.join("/tmp/ws-filter-test", "skills", "my-skill", "index.ts"));
+
+    // Wait for potential debounce
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(mod.getSkillsSnapshotVersion("/tmp/ws-filter-test")).toBe(versionBefore);
   });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -75,24 +75,34 @@ function resolveWatchPaths(workspaceDir: string, config?: OpenClawConfig): strin
   return paths;
 }
 
-function toWatchGlobRoot(raw: string): string {
-  // Chokidar treats globs as POSIX-ish patterns. Normalize Windows separators
-  // so `*` works consistently across platforms.
-  return raw.replaceAll("\\", "/").replace(/\/+$/, "");
+/** Check whether a changed path is a SKILL.md file inside one of the skill roots. */
+export function isSkillPath(changedPath: string, watchRoots: string[]): boolean {
+  if (!path.basename(changedPath).toUpperCase().startsWith("SKILL.MD")) {
+    return false;
+  }
+  const resolved = path.resolve(changedPath);
+  for (const root of watchRoots) {
+    const rel = path.relative(root, resolved);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      continue;
+    }
+    // SKILL.md directly inside root, or <skillName>/SKILL.md (one level deep)
+    const depth = rel.split(path.sep).length;
+    if (depth <= 2) {
+      return true;
+    }
+  }
+  return false;
 }
 
-function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
-  // Skills are defined by SKILL.md; watch only those files to avoid traversing
-  // or watching unrelated large trees (e.g. datasets) that can exhaust FDs.
-  const targets = new Set<string>();
+function resolveWatchRoots(workspaceDir: string, config?: OpenClawConfig): string[] {
+  // Watch skill root directories directly (not globs) so that chokidar
+  // detects directories created after the watcher starts.
+  const roots = new Set<string>();
   for (const root of resolveWatchPaths(workspaceDir, config)) {
-    const globRoot = toWatchGlobRoot(root);
-    // Some configs point directly at a skill folder.
-    targets.add(`${globRoot}/SKILL.md`);
-    // Standard layout: <skillsRoot>/<skillName>/SKILL.md
-    targets.add(`${globRoot}/*/SKILL.md`);
+    roots.add(root);
   }
-  return Array.from(targets).toSorted();
+  return Array.from(roots).toSorted();
 }
 
 export function registerSkillsChangeListener(listener: (event: SkillsChangeEvent) => void) {
@@ -153,8 +163,8 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     return;
   }
 
-  const watchTargets = resolveWatchTargets(workspaceDir, params.config);
-  const pathsKey = watchTargets.join("|");
+  const watchRoots = resolveWatchRoots(workspaceDir, params.config);
+  const pathsKey = watchRoots.join("|");
   if (existing && existing.pathsKey === pathsKey && existing.debounceMs === debounceMs) {
     return;
   }
@@ -166,20 +176,24 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     void existing.watcher.close().catch(() => {});
   }
 
-  const watcher = chokidar.watch(watchTargets, {
+  const watcher = chokidar.watch(watchRoots, {
     ignoreInitial: true,
+    // Limit depth: SKILL.md is at root or one level deep (<skillName>/SKILL.md).
+    depth: 1,
     awaitWriteFinish: {
       stabilityThreshold: debounceMs,
       pollInterval: 100,
     },
-    // Avoid FD exhaustion on macOS when a workspace contains huge trees.
-    // This watcher only needs to react to SKILL.md changes.
     ignored: DEFAULT_SKILLS_WATCH_IGNORED,
   });
 
   const state: SkillsWatchState = { watcher, pathsKey, debounceMs };
 
   const schedule = (changedPath?: string) => {
+    // Only react to SKILL.md files inside skill roots.
+    if (changedPath && !isSkillPath(changedPath, watchRoots)) {
+      return;
+    }
     state.pendingPath = changedPath ?? state.pendingPath;
     if (state.timer) {
       clearTimeout(state.timer);

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -24,6 +24,7 @@ import {
 import {
   buildFileEntry,
   ensureDir,
+  isMemoryPath,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
   runWithConcurrency,
@@ -352,30 +353,24 @@ export abstract class MemoryManagerSyncOps {
     if (!this.sources.has("memory") || !this.settings.sync.watch || this.watcher) {
       return;
     }
-    const watchPaths = new Set<string>([
-      path.join(this.workspaceDir, "MEMORY.md"),
-      path.join(this.workspaceDir, "memory.md"),
-      path.join(this.workspaceDir, "memory", "**", "*.md"),
-    ]);
-    const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
-    for (const entry of additionalPaths) {
+
+    // Watch project root and extra paths directly (non-glob) to ensure
+    // subdirectories created later (like memory/) are captured by chokidar.
+    const watchRoots = new Set<string>([this.workspaceDir]);
+    const normalizedExtraPaths = normalizeExtraMemoryPaths(
+      this.workspaceDir,
+      this.settings.extraPaths,
+    );
+    for (const entry of normalizedExtraPaths) {
       try {
         const stat = fsSync.lstatSync(entry);
-        if (stat.isSymbolicLink()) {
-          continue;
+        if (!stat.isSymbolicLink()) {
+          watchRoots.add(entry);
         }
-        if (stat.isDirectory()) {
-          watchPaths.add(path.join(entry, "**", "*.md"));
-          continue;
-        }
-        if (stat.isFile() && entry.toLowerCase().endsWith(".md")) {
-          watchPaths.add(entry);
-        }
-      } catch {
-        // Skip missing/unreadable additional paths.
-      }
+      } catch {}
     }
-    this.watcher = chokidar.watch(Array.from(watchPaths), {
+
+    this.watcher = chokidar.watch(Array.from(watchRoots), {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
       awaitWriteFinish: {
@@ -383,10 +378,33 @@ export abstract class MemoryManagerSyncOps {
         pollInterval: 100,
       },
     });
-    const markDirty = () => {
-      this.dirty = true;
-      this.scheduleWatchSync();
+
+    const markDirty = (p: string) => {
+      const absPath = path.resolve(p);
+
+      // 1. Check if it's a relevant file in the workspace
+      const relWorkspace = path.relative(this.workspaceDir, absPath);
+      if (!relWorkspace.startsWith("..") && !path.isAbsolute(relWorkspace)) {
+        if (isMemoryPath(relWorkspace)) {
+          this.dirty = true;
+          this.scheduleWatchSync();
+          return;
+        }
+      }
+
+      // 2. Check if it's a markdown file in extra paths
+      for (const extraRoot of normalizedExtraPaths) {
+        const relExtra = path.relative(extraRoot, absPath);
+        if (!relExtra.startsWith("..") && !path.isAbsolute(relExtra)) {
+          if (absPath.toLowerCase().endsWith(".md")) {
+            this.dirty = true;
+            this.scheduleWatchSync();
+            return;
+          }
+        }
+      }
     };
+
     this.watcher.on("add", markDirty);
     this.watcher.on("change", markDirty);
     this.watcher.on("unlink", markDirty);

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -5,12 +5,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
 
-const { watchMock } = vi.hoisted(() => ({
-  watchMock: vi.fn(() => ({
-    on: vi.fn(),
-    close: vi.fn(async () => undefined),
-  })),
-}));
+type WatcherHandler = (p: string) => void;
+
+const { watchMock } = vi.hoisted(() => {
+  const handlers = new Map<string, WatcherHandler>();
+  return {
+    watchMock: vi.fn(() => ({
+      on: vi.fn((event: string, handler: WatcherHandler) => {
+        handlers.set(event, handler);
+      }),
+      close: vi.fn(async () => undefined),
+      _handlers: handlers,
+    })),
+  };
+});
 
 vi.mock("chokidar", () => ({
   default: { watch: watchMock },
@@ -51,13 +59,7 @@ describe("memory watcher config", () => {
     }
   });
 
-  it("watches markdown globs and ignores dependency directories", async () => {
-    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
-    extraDir = path.join(workspaceDir, "extra");
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.mkdir(extraDir, { recursive: true });
-    await fs.writeFile(path.join(extraDir, "notes.md"), "hello");
-
+  async function createManager(opts?: { extraPaths?: string[] }) {
     const cfg = {
       agents: {
         defaults: {
@@ -68,7 +70,7 @@ describe("memory watcher config", () => {
             store: { path: path.join(workspaceDir, "index.sqlite"), vector: { enabled: false } },
             sync: { watch: true, watchDebounceMs: 25, onSessionStart: false, onSearch: false },
             query: { minScore: 0, hybrid: { enabled: false } },
-            extraPaths: [extraDir],
+            extraPaths: opts?.extraPaths ?? [],
           },
         },
         list: [{ id: "main", default: true }],
@@ -81,20 +83,34 @@ describe("memory watcher config", () => {
       throw new Error("manager missing");
     }
     manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  it("watches workspace root and extra paths directly (not globs)", async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
+    extraDir = path.join(workspaceDir, "extra");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "notes.md"), "hello");
+
+    await createManager({ extraPaths: [extraDir] });
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const [watchedPaths, options] = watchMock.mock.calls[0] as unknown as [
       string[],
       Record<string, unknown>,
     ];
-    expect(watchedPaths).toEqual(
-      expect.arrayContaining([
-        path.join(workspaceDir, "MEMORY.md"),
-        path.join(workspaceDir, "memory.md"),
-        path.join(workspaceDir, "memory", "**", "*.md"),
-        path.join(extraDir, "**", "*.md"),
-      ]),
-    );
+
+    // Should watch root directories directly, not glob patterns
+    expect(watchedPaths).toContain(workspaceDir);
+    expect(watchedPaths).toContain(extraDir);
+
+    // Should NOT contain glob patterns (the old bug)
+    for (const p of watchedPaths) {
+      expect(p).not.toContain("**");
+      expect(p).not.toContain("*.md");
+    }
+
     expect(options.ignoreInitial).toBe(true);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
@@ -105,5 +121,104 @@ describe("memory watcher config", () => {
     );
     expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
     expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
+  });
+
+  it("markDirty filters: only memory paths in workspace trigger dirty", async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+
+    await createManager();
+
+    const mockWatcher = watchMock.mock.results[0]?.value as {
+      _handlers: Map<string, WatcherHandler>;
+    };
+    const addHandler = mockWatcher._handlers.get("add");
+    expect(addHandler).toBeTypeOf("function");
+
+    if (!addHandler) {
+      throw new Error("add handler not registered");
+    }
+
+    // memory/foo.md should trigger dirty
+    addHandler(path.join(workspaceDir, "memory", "foo.md"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(true);
+
+    // Reset
+    (manager as unknown as { dirty: boolean }).dirty = false;
+
+    // MEMORY.md should trigger dirty
+    addHandler(path.join(workspaceDir, "MEMORY.md"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(true);
+
+    // Reset
+    (manager as unknown as { dirty: boolean }).dirty = false;
+
+    // memory.md should trigger dirty
+    addHandler(path.join(workspaceDir, "memory.md"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(true);
+
+    // Reset
+    (manager as unknown as { dirty: boolean }).dirty = false;
+
+    // src/foo.ts should NOT trigger dirty
+    addHandler(path.join(workspaceDir, "src", "foo.ts"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(false);
+
+    // package.json should NOT trigger dirty
+    addHandler(path.join(workspaceDir, "package.json"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(false);
+  });
+
+  it("markDirty filters: markdown files in extra paths trigger dirty", async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
+    extraDir = path.join(workspaceDir, "extra");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "notes.md"), "hello");
+
+    await createManager({ extraPaths: [extraDir] });
+
+    const mockWatcher = watchMock.mock.results[0]?.value as {
+      _handlers: Map<string, WatcherHandler>;
+    };
+    const addHandler = mockWatcher._handlers.get("add");
+    expect(addHandler).toBeTypeOf("function");
+
+    if (!addHandler) {
+      throw new Error("add handler not registered");
+    }
+
+    // .md file in extra path should trigger dirty
+    addHandler(path.join(extraDir, "notes.md"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(true);
+
+    // Reset
+    (manager as unknown as { dirty: boolean }).dirty = false;
+
+    // .txt file in extra path should NOT trigger dirty
+    addHandler(path.join(extraDir, "data.txt"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(false);
+  });
+
+  it("detects memory files created after watcher starts (late directory creation)", async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
+    // NOTE: memory/ directory does NOT exist at watcher start time
+
+    await createManager();
+
+    const mockWatcher = watchMock.mock.results[0]?.value as {
+      _handlers: Map<string, WatcherHandler>;
+    };
+    const addHandler = mockWatcher._handlers.get("add");
+    expect(addHandler).toBeTypeOf("function");
+
+    if (!addHandler) {
+      throw new Error("add handler not registered");
+    }
+
+    // Simulate: memory/ directory is created later, then a file is added
+    // Because we watch the workspace root (not a glob), chokidar detects this.
+    // The handler correctly identifies it as a memory path via isMemoryPath().
+    addHandler(path.join(workspaceDir, "memory", "new-note.md"));
+    expect((manager as unknown as { dirty: boolean }).dirty).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Chokidar resolves glob patterns at startup time. If the target directory (e.g. `memory/`, `skills/`) doesn't exist when the watcher is created, the glob matches nothing and **no inotify watch is ever established** — even after the directory is created later. This creates a persistent blind spot where new files are never detected until a manual restart or unrelated file change triggers re-indexing.

## Root Cause

Both the memory indexing watcher (`manager-sync-ops.ts`) and the skills refresh watcher (`refresh.ts`) used glob patterns like `memory/**/*.md` and `{skillsRoot}/*/SKILL.md`. These directories are commonly absent at session start and created on-demand.

## Fix

**Memory watcher** (`src/memory/manager-sync-ops.ts`):
- Watch workspace root and extra paths directly (not globs)
- Filter events via `isMemoryPath()` — only `MEMORY.md`, `memory.md`, and files under `memory/` trigger re-indexing

**Skills watcher** (`src/agents/skills/refresh.ts`):
- Watch skill root directories directly with `depth: 1`
- Filter events via new `isSkillPath()` — only `SKILL.md` files at root or one level deep trigger a version bump

## Not affected
- Canvas host watcher (`server.ts`) — directory is ensured to exist before watching via `prepareCanvasRoot()`
- Gateway config watcher (`config-reload.ts`) — watches a single file path, not a glob

## Tests

- **Memory watcher** (4 tests): non-glob watching, `markDirty` filtering for workspace/extra paths, late directory creation scenario
- **Skills watcher** (7 tests): non-glob watching, `isSkillPath` depth/basename/boundary checks, event filtering integration