### PR TITLE
Update: disable self-update for managed deployments

### DIFF
--- a/phala-deploy/openclaw.template.json
+++ b/phala-deploy/openclaw.template.json
@@ -39,7 +39,11 @@
     }
   },
   "update": {
-    "checkOnStart": false
+    "checkOnStart": false,
+    "selfUpdate": {
+      "enabled": false,
+      "reason": "This Clawdi deployment is managed by the Phala image rollout workflow. In-place OpenClaw self-update would replace it with an incompatible upstream package and can brick the deployment."
+    }
   },
   "commands": {
     "native": "auto",

--- a/phala-deploy/openclaw.template.json
+++ b/phala-deploy/openclaw.template.json
@@ -42,7 +42,7 @@
     "checkOnStart": false,
     "selfUpdate": {
       "enabled": false,
-      "reason": "This Clawdi deployment is managed by the Phala image rollout workflow. In-place OpenClaw self-update would replace it with an incompatible upstream package and can brick the deployment."
+      "reason": "This Clawdi deployment is managed by the Clawdi dashboard. Please use the Clawdi dashboard to update this deployment."
     }
   },
   "commands": {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -470,6 +470,74 @@ describe("update-cli", () => {
     );
   });
 
+  it("skips package-manager self-update when disabled by config", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      config: {
+        update: {
+          selfUpdate: {
+            enabled: false,
+            reason: "Managed by Clawdi rollout.",
+          },
+        },
+      } as OpenClawConfig,
+    });
+    vi.mocked(defaultRuntime.log).mockClear();
+    vi.mocked(runCommandWithTimeout).mockClear();
+
+    await updateCommand({ yes: true });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(
+      vi
+        .mocked(runCommandWithTimeout)
+        .mock.calls.some(
+          (call) =>
+            Array.isArray(call[0]) &&
+            call[0][0] === "npm" &&
+            call[0][1] === "i" &&
+            call[0][2] === "-g",
+        ),
+    ).toBe(false);
+    expect(
+      vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("Self-update is disabled: Managed by Clawdi rollout.");
+  });
+
+  it("skips package-to-dev self-update when disabled by config", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      config: {
+        update: {
+          selfUpdate: {
+            enabled: false,
+            reason: "Managed by Clawdi rollout.",
+          },
+        },
+      } as OpenClawConfig,
+    });
+    vi.mocked(defaultRuntime.log).mockClear();
+    vi.mocked(runCommandWithTimeout).mockClear();
+
+    await updateCommand({ yes: true, channel: "dev" });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
+    expect(
+      vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("Self-update is disabled: Managed by Clawdi rollout.");
+  });
+
   it("prepends portable Git PATH for package updates on Windows", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const tempDir = createCaseDir("openclaw-update");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -13,6 +13,11 @@ import {
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import {
+  isSelfUpdateDisabled,
+  resolveSelfUpdateDisabledReason,
+  type SelfUpdatePolicy,
+} from "../../infra/self-update-policy.js";
+import {
   channelToNpmTag,
   DEFAULT_GIT_CHANNEL,
   DEFAULT_PACKAGE_CHANNEL,
@@ -306,7 +311,19 @@ async function runPackageInstallUpdate(params: {
   timeoutMs: number;
   startedAt: number;
   progress: ReturnType<typeof createUpdateProgress>["progress"];
+  selfUpdatePolicy?: SelfUpdatePolicy;
 }): Promise<UpdateRunResult> {
+  if (isSelfUpdateDisabled(params.selfUpdatePolicy)) {
+    return {
+      status: "skipped",
+      mode: "unknown",
+      root: params.root,
+      reason: resolveSelfUpdateDisabledReason(params.selfUpdatePolicy),
+      steps: [],
+      durationMs: Date.now() - params.startedAt,
+    };
+  }
+
   const manager = await resolveGlobalManager({
     root: params.root,
     installKind: params.installKind,
@@ -383,7 +400,19 @@ async function runGitUpdate(params: {
   showProgress: boolean;
   opts: UpdateCommandOptions;
   stop: () => void;
+  selfUpdatePolicy?: SelfUpdatePolicy;
 }): Promise<UpdateRunResult> {
+  if (params.switchToGit && isSelfUpdateDisabled(params.selfUpdatePolicy)) {
+    return {
+      status: "skipped",
+      mode: "unknown",
+      root: params.root,
+      reason: resolveSelfUpdateDisabledReason(params.selfUpdatePolicy),
+      steps: [],
+      durationMs: Date.now() - params.startedAt,
+    };
+  }
+
   const updateRoot = params.switchToGit ? resolveGitInstallDir() : params.root;
   const effectiveTimeout = params.timeoutMs ?? 20 * 60_000;
 
@@ -417,6 +446,7 @@ async function runGitUpdate(params: {
     progress: params.progress,
     channel: params.channel,
     tag: params.tag,
+    selfUpdatePolicy: params.selfUpdatePolicy,
   });
   const steps = [...(cloneStep ? [cloneStep] : []), ...updateResult.steps];
 
@@ -898,6 +928,9 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
           timeoutMs: timeoutMs ?? 20 * 60_000,
           startedAt,
           progress,
+          selfUpdatePolicy: configSnapshot.valid
+            ? configSnapshot.config.update?.selfUpdate
+            : undefined,
         })
       : await runGitUpdate({
           root,
@@ -911,6 +944,9 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
           showProgress,
           opts,
           stop,
+          selfUpdatePolicy: configSnapshot.valid
+            ? configSnapshot.config.update?.selfUpdate
+            : undefined,
         });
 
   stop();

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -1,4 +1,5 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { loadConfig } from "../config/config.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -52,9 +53,11 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
       return { updated: false };
     }
     note("Running update (fetch/rebase/build/ui:build/doctor)…", "Update");
+    const config = loadConfig();
     const result = await runGatewayUpdate({
       cwd: params.root,
       argv1: process.argv[1],
+      selfUpdatePolicy: config.update?.selfUpdate,
     });
     note(
       [

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -60,6 +60,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Update-channel and startup-check behavior for keeping OpenClaw runtime versions current. Use conservative channels in production and more experimental channels only in controlled environments.",
   "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
   "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
+  "update.selfUpdate.enabled":
+    "Allow OpenClaw to update itself in-place through the CLI updater, gateway update.run, or auto-update flows (default: true). Disable this for externally managed deployments that must be updated by image rollout or another operator workflow.",
+  "update.selfUpdate.reason":
+    "Optional explanation shown when self-update is blocked. Use this to point operators at the correct external upgrade workflow for managed deployments.",
   "update.auto.enabled": "Enable background auto-update for package installs (default: false).",
   "update.auto.stableDelayHours":
     "Minimum delay before stable-channel auto-apply starts (default: 6).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -32,6 +32,8 @@ export const FIELD_LABELS: Record<string, string> = {
   update: "Updates",
   "update.channel": "Update Channel",
   "update.checkOnStart": "Update Check on Start",
+  "update.selfUpdate.enabled": "Self Update Enabled",
+  "update.selfUpdate.reason": "Self Update Disabled Reason",
   "update.auto.enabled": "Auto Update Enabled",
   "update.auto.stableDelayHours": "Auto Update Stable Delay (hours)",
   "update.auto.stableJitterHours": "Auto Update Stable Jitter (hours)",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -68,6 +68,13 @@ export type OpenClawConfig = {
     channel?: "stable" | "beta" | "dev";
     /** Check for updates on gateway start (npm installs only). */
     checkOnStart?: boolean;
+    /** Policy controlling whether OpenClaw may update itself in-place. */
+    selfUpdate?: {
+      /** Allow in-place self-updates (CLI update / update.run / auto-update). Default: true. */
+      enabled?: boolean;
+      /** Optional operator-facing explanation shown when self-update is blocked. */
+      reason?: string;
+    };
     /** Core auto-update policy for package installs. */
     auto?: {
       /** Enable background auto-update checks and apply logic. Default: false. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -314,6 +314,13 @@ export const OpenClawSchema = z
       .object({
         channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),
         checkOnStart: z.boolean().optional(),
+        selfUpdate: z
+          .object({
+            enabled: z.boolean().optional(),
+            reason: z.string().optional(),
+          })
+          .strict()
+          .optional(),
         auto: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -44,6 +44,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         cwd: root,
         argv1: process.argv[1],
         channel: configChannel ?? undefined,
+        selfUpdatePolicy: config.update?.selfUpdate,
       });
     } catch (err) {
       result = {

--- a/src/infra/self-update-policy.ts
+++ b/src/infra/self-update-policy.ts
@@ -1,0 +1,19 @@
+export type SelfUpdatePolicy = {
+  enabled?: boolean;
+  reason?: string;
+};
+
+const DEFAULT_SELF_UPDATE_DISABLED_REASON =
+  "Self-update is disabled for this deployment. Update it through the external deployment workflow instead of running OpenClaw's in-place updater.";
+
+export function isSelfUpdateDisabled(policy?: SelfUpdatePolicy): boolean {
+  return policy?.enabled === false;
+}
+
+export function resolveSelfUpdateDisabledReason(policy?: SelfUpdatePolicy): string {
+  const reason = policy?.reason?.trim();
+  if (!reason) {
+    return DEFAULT_SELF_UPDATE_DISABLED_REASON;
+  }
+  return `Self-update is disabled: ${reason}`;
+}

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -160,12 +160,18 @@ describe("runGatewayUpdate", () => {
       argv: string[],
       options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
     ) => Promise<CommandResult>,
-    options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string },
+    options?: {
+      channel?: "stable" | "beta";
+      tag?: string;
+      cwd?: string;
+      selfUpdatePolicy?: { enabled?: boolean; reason?: string };
+    },
   ) {
     return runGatewayUpdate({
       cwd: options?.cwd ?? tempDir,
       runCommand: async (argv, runOptions) => runCommand(argv, runOptions),
       timeoutMs: 5000,
+      ...(options?.selfUpdatePolicy ? { selfUpdatePolicy: options.selfUpdatePolicy } : {}),
       ...(options?.channel ? { channel: options.channel } : {}),
       ...(options?.tag ? { tag: options.tag } : {}),
     });
@@ -439,6 +445,28 @@ describe("runGatewayUpdate", () => {
     expect(result.before?.version).toBe("1.0.0");
     expect(result.after?.version).toBe("2.0.0");
     expect(calls.some((call) => call === expectedInstallCommand)).toBe(true);
+  });
+
+  it("skips package-manager self-update when disabled by config policy", async () => {
+    const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
+    const { calls, runCommand } = createGlobalInstallHarness({
+      pkgRoot,
+      npmRootOutput: nodeModules,
+      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      onInstall: async () => writeGlobalPackageVersion(pkgRoot),
+    });
+
+    const result = await runWithCommand(runCommand, {
+      cwd: pkgRoot,
+      selfUpdatePolicy: {
+        enabled: false,
+        reason: "Managed by Clawdi rollout.",
+      },
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("Self-update is disabled: Managed by Clawdi rollout.");
+    expect(calls.some((call) => call.startsWith("npm i -g"))).toBe(false);
   });
 
   it("falls back to global npm update when git is missing from PATH", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -10,6 +10,11 @@ import { detectPackageManager as detectPackageManagerImpl } from "./detect-packa
 import { readPackageName, readPackageVersion } from "./package-json.js";
 import { normalizePackageTagInput } from "./package-tag.js";
 import { trimLogTail } from "./restart-sentinel.js";
+import {
+  isSelfUpdateDisabled,
+  resolveSelfUpdateDisabledReason,
+  type SelfUpdatePolicy,
+} from "./self-update-policy.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import {
   channelToNpmTag,
@@ -79,6 +84,7 @@ type UpdateRunnerOptions = {
   tag?: string;
   channel?: UpdateChannel;
   timeoutMs?: number;
+  selfUpdatePolicy?: SelfUpdatePolicy;
   runCommand?: CommandRunner;
   progress?: UpdateStepProgress;
 };
@@ -864,6 +870,17 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
   }
 
   const beforeVersion = await readPackageVersion(pkgRoot);
+  if (isSelfUpdateDisabled(opts.selfUpdatePolicy)) {
+    return {
+      status: "skipped",
+      mode: "unknown",
+      root: pkgRoot,
+      reason: resolveSelfUpdateDisabledReason(opts.selfUpdatePolicy),
+      before: { version: beforeVersion },
+      steps: [],
+      durationMs: Date.now() - startedAt,
+    };
+  }
   const globalManager = await detectGlobalInstallManagerForRoot(runCommand, pkgRoot, timeoutMs);
   if (globalManager) {
     const packageName = (await readPackageName(pkgRoot)) ?? DEFAULT_PACKAGE_NAME;


### PR DESCRIPTION
## Summary

- Problem: Clawdi Phala deployments can still trigger OpenClaw's in-place self-update paths, including package-manager installs that replace the managed Clawdi distribution with incompatible vanilla OpenClaw bits.
- Why it matters: a user-triggered self-update can brick the deployment, especially because the rendered Clawdi/Phala config is not compatible with the vanilla upstream package/update flow.
- What changed: added `update.selfUpdate.enabled/reason`, block package-install self-update when disabled, and set the Clawdi Phala template to disable self-update with an operator-facing reason.
- What did NOT change (scope boundary): this does not hide update UI/actions, change git-checkout update behavior, or add a Phala migration script.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/Clawdi-AI/clawdi/issues/174

## User-visible / Behavior Changes

- Managed deployments can set `update.selfUpdate.enabled=false` and an optional `update.selfUpdate.reason`.
- When disabled, package-manager self-update paths now return `skipped` with the configured reason instead of running `npm`/`pnpm`/`bun` installs.
- The Clawdi Phala template now ships with self-update disabled by default.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This narrows the update execution surface for managed deployments by refusing in-place package installs when the config disables self-update.

## Repro + Verification

### Environment

- OS: Ubuntu (dev workspace)
- Runtime/container: Node 24 / pnpm
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `update.selfUpdate.enabled=false`

### Steps

1. Configure a package-installed OpenClaw deployment with `update.selfUpdate.enabled=false`.
2. Run `openclaw update` or trigger `update.run` through the gateway/control plane.
3. Observe the result.

### Expected

- The update is skipped with a clear operator-facing reason.
- No package-manager install command is executed.

### Actual

- Before this change, package-manager self-update could run and replace the managed Clawdi install.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/infra/update-runner.test.ts` covers package-manager update blocking.
  - `src/cli/update-cli.test.ts` covers both normal package updates and package-to-dev switch flows being blocked when self-update is disabled.
  - `pnpm build` passed.
- Edge cases checked:
  - package install path
  - package-to-dev/git-switch path
  - explicit disabled reason propagation
- What you did **not** verify:
  - a live Phala deployment after config rollout

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `update.selfUpdate` from config or set `update.selfUpdate.enabled=true`.
- Files/config to restore:
  - `openclaw.json`
  - `phala-deploy/openclaw.template.json`
- Known bad symptoms reviewers should watch for:
  - package-installed non-managed environments unexpectedly seeing update skips because `update.selfUpdate.enabled=false` was set in config

## Risks and Mitigations

- Risk:
  - Managed-deployment opt-out could accidentally be applied to an environment that still expects in-place package updates.
- Mitigation:
  - The block is fully config-driven, returns a clear reason, and defaults to unchanged behavior unless the flag is explicitly set.
