### PR TITLE
Tests: fix legacy compat restart harness

### DIFF
--- a/phala-deploy/integration-test/mux-openclaw-harness.ts
+++ b/phala-deploy/integration-test/mux-openclaw-harness.ts
@@ -98,7 +98,7 @@ function buildHarnessEnv(
     channel?: "telegram" | "discord" | "whatsapp";
     minimalGateway?: boolean;
   },
-): Record<string, string> {
+): Record<string, string | undefined> {
   const isMinimalGateway = params?.minimalGateway !== false;
   const integrationChannels =
     params?.channel === "discord"
@@ -119,11 +119,9 @@ function buildHarnessEnv(
     OPENCLAW_SKIP_CRON: "1",
     OPENCLAW_GATEWAY_TOKEN: GATEWAY_TOKEN,
     OPENCLAW_INTEGRATION_CHANNELS: integrationChannels,
-    ...(isMinimalGateway
-      ? {
-          OPENCLAW_SKIP_CHANNELS: "1",
-        }
-      : {}),
+    OPENCLAW_SKIP_CHANNELS: isMinimalGateway ? "1" : undefined,
+    OPENCLAW_SKIP_PROVIDERS: isMinimalGateway ? "1" : undefined,
+    OPENCLAW_TEST_MINIMAL_GATEWAY: isMinimalGateway ? "1" : undefined,
   };
 }
 
@@ -310,6 +308,7 @@ async function startGatewayProcess(params: {
   env: Record<string, string>;
   runtime?: "current" | "legacy";
   legacyRepoPath?: string;
+  skipHealthzCheck?: boolean;
 }): Promise<StartedNodeProcess> {
   const integrationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
   const started =
@@ -326,16 +325,31 @@ async function startGatewayProcess(params: {
           args: [String(params.port)],
           env: params.env,
         });
+
+  const ensureProcessAlive = () => {
+    if (started.process.exitCode !== null) {
+      throw new Error(
+        `gateway process exited early (${started.process.exitCode})\n${started.logs.join("").slice(-8_000)}`,
+      );
+    }
+  };
+
+  if (params.skipHealthzCheck) {
+    await waitForCondition(
+      () => {
+        ensureProcessAlive();
+        return started.logs.join("").includes(`__INTEGRATION_GATEWAY_READY__:${params.port}`);
+      },
+      20_000,
+      `gateway process did not become ready\n${started.logs.join("").slice(-8_000)}`,
+    );
+    return started;
+  }
+
   await waitForHttpOk({
     url: `http://127.0.0.1:${params.port}/healthz`,
     timeoutMs: 20_000,
-    onTick: () => {
-      if (started.process.exitCode !== null) {
-        throw new Error(
-          `gateway process exited early (${started.process.exitCode})\n${started.logs.join("").slice(-8_000)}`,
-        );
-      }
-    },
+    onTick: ensureProcessAlive,
     errorMessage: () =>
       `gateway process did not become ready\n${started.logs.join("").slice(-8_000)}`,
   });
@@ -416,7 +430,13 @@ export async function startMuxOpenClawHarness(
       channel,
       minimalGateway: params.minimalGateway,
     });
-    Object.assign(process.env, harnessEnv);
+    for (const [key, value] of Object.entries(harnessEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     await mkdir(paths.workspaceDir, { recursive: true });
     if (params.workspaceFiles) {
       for (const [relativePath, content] of Object.entries(params.workspaceFiles)) {
@@ -466,6 +486,7 @@ export async function startMuxOpenClawHarness(
       env: harnessEnv,
       runtime,
       legacyRepoPath: params.legacyRepoPath,
+      skipHealthzCheck: runtime === "legacy",
     });
     cleanup.defer(async () => {
       await stopChildProcess(gateway.process);
@@ -552,6 +573,7 @@ export async function startMuxOpenClawHarness(
           env: harnessEnv,
           runtime,
           legacyRepoPath: params.legacyRepoPath,
+          skipHealthzCheck: runtime === "legacy",
         });
       },
       close: async () => {

--- a/phala-deploy/integration-test/telegram.legacy-openclaw-compat.e2e.test.ts
+++ b/phala-deploy/integration-test/telegram.legacy-openclaw-compat.e2e.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, test } from "vitest";
-import { callGateway } from "../../src/gateway/call.js";
 import {
   loadPendingDeliveries,
   type QueuedDelivery,
@@ -33,6 +33,20 @@ function resolveLegacyRepoPath(): string | null {
 const legacyRepoPath = resolveLegacyRepoPath();
 const shouldRunLegacyCompat =
   process.env.OPENCLAW_RUN_LEGACY_COMPAT === "1" && Boolean(legacyRepoPath);
+
+type GatewayCaller = typeof import("../../src/gateway/call.js").callGateway;
+
+let cachedLegacyCallGateway: Promise<GatewayCaller> | null = null;
+
+async function resolveLegacyCallGateway(): Promise<GatewayCaller> {
+  if (!legacyRepoPath) {
+    throw new Error("legacy repo path is required");
+  }
+  cachedLegacyCallGateway ??= import(
+    pathToFileURL(path.join(legacyRepoPath, "src", "gateway", "call.ts")).href
+  ).then((mod) => mod.callGateway as GatewayCaller);
+  return await cachedLegacyCallGateway;
+}
 
 async function waitForPendingDeliveries(
   stateDir: string,
@@ -213,6 +227,7 @@ describe("mux Telegram real legacy OpenClaw compatibility", () => {
   legacyTest("replays queued legacy gateway send after restart", { timeout: 180_000 }, async () => {
     const scenario = requireScenario("dm-text-legacy-binding");
     const message = "LEGACY_RESTART_GATEWAY_SEND";
+    const callLegacyGateway = await resolveLegacyCallGateway();
 
     await withMuxOpenClawHarness(
       {
@@ -230,7 +245,7 @@ describe("mux Telegram real legacy OpenClaw compatibility", () => {
           harness.telegram.setMethodFailure("sendMessage", { status: 500 });
 
           await expect(
-            callGateway({
+            callLegacyGateway({
               url: harness.gatewayUrl,
               token: harness.gatewayToken,
               method: "send",


### PR DESCRIPTION
## Summary
- fix legacy harness env handling so non-minimal gateway runs clear inherited skip flags
- preserve the legacy ready-marker startup path across gateway restarts
- make the legacy restart-replay compat test use the legacy repo's own gateway client

## Root Cause
The remaining legacy replay failure was not a real runtime regression.

Two harness issues were stacked together:
1. the integration harness could inherit `OPENCLAW_SKIP_CHANNELS` style flags from the parent test process and keep the legacy gateway in the wrong startup mode
2. the restart-replay compat test seeded a `2026.2.17-phala.7` gateway with the current repo's `callGateway()` client, which is not fully device-auth compatible with that legacy server

Using the legacy repo's own `callGateway()` makes the queued-send replay pass.

## Verification
- `OPENCLAW_RUN_LEGACY_COMPAT=1 OPENCLAW_LEGACY_REPO=/tmp/openclaw-2026.2.17-phala.7.M6naPQ pnpm exec vitest run --config phala-deploy/integration-test/vitest.config.ts phala-deploy/integration-test/telegram.legacy-openclaw-compat.e2e.test.ts -t "replays queued legacy gateway send after restart" --reporter verbose`
- `OPENCLAW_RUN_LEGACY_COMPAT=1 OPENCLAW_LEGACY_REPO=/tmp/openclaw-2026.2.17-phala.7.M6naPQ pnpm exec vitest run --config phala-deploy/integration-test/vitest.config.ts phala-deploy/integration-test/telegram.legacy-openclaw-compat.e2e.test.ts phala-deploy/integration-test/nontelegram.legacy-openclaw-compat.e2e.test.ts --reporter dot`
