### PR TITLE
Mux: persist inbound attachments in media store

### DIFF
--- a/src/gateway/mux-http.test.ts
+++ b/src/gateway/mux-http.test.ts
@@ -1164,184 +1164,189 @@ describe("handleMuxInboundHttpRequest", () => {
   );
 
   test("sets ctx.MediaPaths and MediaTypes from base64 content attachment", async () => {
-    const jwtFixture = createJwtFixture();
-    const fetchMock = vi.fn<
-      (input: string | URL | Request, init?: RequestInit) => Promise<Response>
-    >(async (input) => {
-      const url = resolveFetchUrl(input);
-      if (url === "http://mux.local/.well-known/jwks.json") {
-        return new Response(JSON.stringify(jwtFixture.jwks), {
-          status: 200,
-          headers: { "Content-Type": "application/json; charset=utf-8" },
-        });
-      }
-      throw new Error(`unexpected fetch url ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    await withTempStateDir(async () => {
+      const jwtFixture = createJwtFixture();
+      const fetchMock = vi.fn<
+        (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+      >(async (input) => {
+        const url = resolveFetchUrl(input);
+        if (url === "http://mux.local/.well-known/jwks.json") {
+          return new Response(JSON.stringify(jwtFixture.jwks), {
+            status: 200,
+            headers: { "Content-Type": "application/json; charset=utf-8" },
+          });
+        }
+        throw new Error(`unexpected fetch url ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
 
-    const token = await jwtFixture.mintToken({
-      issuer: "http://mux.local",
-      subject: OPENCLAW_ID,
-      audience: "openclaw-mux-inbound",
-      scope: "mux:inbound",
-    });
+      const token = await jwtFixture.mintToken({
+        issuer: "http://mux.local",
+        subject: OPENCLAW_ID,
+        audience: "openclaw-mux-inbound",
+        scope: "mux:inbound",
+      });
 
-    mocks.loadConfig.mockReturnValue({
-      gateway: {
-        http: {
-          endpoints: {
-            mux: {
-              enabled: true,
-              baseUrl: "http://mux.local",
-              registerKey: "rk-test-1",
-              inboundUrl: "http://openclaw.local/v1/mux/inbound",
+      mocks.loadConfig.mockReturnValue({
+        gateway: {
+          http: {
+            endpoints: {
+              mux: {
+                enabled: true,
+                baseUrl: "http://mux.local",
+                registerKey: "rk-test-1",
+                inboundUrl: "http://openclaw.local/v1/mux/inbound",
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    const req = createRequest({
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${token}`,
-        "x-openclaw-id": OPENCLAW_ID,
-      },
-      body: {
-        channel: "telegram",
-        sessionKey: "main",
-        to: "telegram:123",
-        body: "see image",
-        messageId: "mux-img-1",
-        openclawId: OPENCLAW_ID,
-        attachments: [
-          {
-            type: "image",
-            mimeType: "image/png",
-            fileName: "dot.png",
-            content: `data:image/png;base64,${ONE_PIXEL_PNG_BASE64}`,
-          },
-        ],
-      },
-    });
-    const res = createResponse();
-    expect(await handleMuxInboundHttpRequest(req, res)).toBe(true);
-    expect(res.statusCode).toBe(202);
+      const req = createRequest({
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+          "x-openclaw-id": OPENCLAW_ID,
+        },
+        body: {
+          channel: "telegram",
+          sessionKey: "main",
+          to: "telegram:123",
+          body: "see image",
+          messageId: "mux-img-1",
+          openclawId: OPENCLAW_ID,
+          attachments: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              fileName: "dot.png",
+              content: `data:image/png;base64,${ONE_PIXEL_PNG_BASE64}`,
+            },
+          ],
+        },
+      });
+      const res = createResponse();
+      expect(await handleMuxInboundHttpRequest(req, res)).toBe(true);
+      expect(res.statusCode).toBe(202);
 
-    await waitForAsyncDispatch();
-    expect(mocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
-    const call = mocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0] as
-      | {
-          ctx?: {
-            MessageSid?: string;
-            MediaPaths?: string[];
-            MediaTypes?: string[];
-            MediaPath?: string;
-            MediaType?: string;
-          };
-        }
-      | undefined;
-    expect(call?.ctx?.MessageSid).toBe("mux-img-1");
-    expect(call?.ctx?.MediaPaths).toHaveLength(1);
-    expect(call?.ctx?.MediaTypes).toEqual(["image/png"]);
-    expect(call?.ctx?.MediaPath).toBeDefined();
-    expect(call?.ctx?.MediaType).toBe("image/png");
-    // Verify temp file was written with correct content
-    const writtenPath = call?.ctx?.MediaPaths?.[0];
-    expect(writtenPath).toBeDefined();
-    if (writtenPath && fs.existsSync(writtenPath)) {
-      const buffer = fs.readFileSync(writtenPath);
+      await waitForAsyncDispatch();
+      expect(mocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      const call = mocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0] as
+        | {
+            ctx?: {
+              MessageSid?: string;
+              MediaPaths?: string[];
+              MediaTypes?: string[];
+              MediaPath?: string;
+              MediaType?: string;
+            };
+          }
+        | undefined;
+      expect(call?.ctx?.MessageSid).toBe("mux-img-1");
+      expect(call?.ctx?.MediaPaths).toHaveLength(1);
+      expect(call?.ctx?.MediaTypes).toEqual(["image/png"]);
+      expect(call?.ctx?.MediaPath).toBeDefined();
+      expect(call?.ctx?.MediaType).toBe("image/png");
+      const writtenPath = call?.ctx?.MediaPaths?.[0];
+      expect(writtenPath).toBeDefined();
+      expect(writtenPath).toContain(`${path.sep}media${path.sep}inbound${path.sep}`);
+      expect(fs.existsSync(writtenPath!)).toBe(true);
+      const buffer = fs.readFileSync(writtenPath!);
       expect(buffer.toString("base64")).toBe(ONE_PIXEL_PNG_BASE64);
-    }
+    });
   });
 
   test("sets ctx.MediaPaths from attachment URL via fetchMuxFileStream", async () => {
-    const jwtFixture = createJwtFixture();
-    const fetchMock = vi.fn(async (input: string | URL | Request) => {
-      const url = resolveFetchUrl(input);
-      if (url === "http://mux.local/.well-known/jwks.json") {
-        return new Response(JSON.stringify(jwtFixture.jwks), {
-          status: 200,
-          headers: { "Content-Type": "application/json; charset=utf-8" },
-        });
-      }
-      throw new Error(`unexpected fetch url ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    await withTempStateDir(async () => {
+      const jwtFixture = createJwtFixture();
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = resolveFetchUrl(input);
+        if (url === "http://mux.local/.well-known/jwks.json") {
+          return new Response(JSON.stringify(jwtFixture.jwks), {
+            status: 200,
+            headers: { "Content-Type": "application/json; charset=utf-8" },
+          });
+        }
+        throw new Error(`unexpected fetch url ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
 
-    const token = await jwtFixture.mintToken({
-      issuer: "http://mux.local",
-      subject: OPENCLAW_ID,
-      audience: "openclaw-mux-inbound",
-      scope: "mux:inbound",
-    });
+      const token = await jwtFixture.mintToken({
+        issuer: "http://mux.local",
+        subject: OPENCLAW_ID,
+        audience: "openclaw-mux-inbound",
+        scope: "mux:inbound",
+      });
 
-    mocks.loadConfig.mockReturnValue({
-      gateway: {
-        http: {
-          endpoints: {
-            mux: {
-              enabled: true,
-              baseUrl: "http://mux.local",
-              registerKey: "rk-test-1",
-              inboundUrl: "http://openclaw.local/v1/mux/inbound",
+      mocks.loadConfig.mockReturnValue({
+        gateway: {
+          http: {
+            endpoints: {
+              mux: {
+                enabled: true,
+                baseUrl: "http://mux.local",
+                registerKey: "rk-test-1",
+                inboundUrl: "http://openclaw.local/v1/mux/inbound",
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    const pdfBytes = Buffer.from("fake-pdf-content");
-    mocks.fetchMuxFileStream.mockResolvedValue(new Response(pdfBytes, { status: 200 }));
+      const pdfBytes = Buffer.from("fake-pdf-content");
+      mocks.fetchMuxFileStream.mockResolvedValue(new Response(pdfBytes, { status: 200 }));
 
-    const req = createRequest({
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${token}`,
-        "x-openclaw-id": OPENCLAW_ID,
-      },
-      body: {
-        channel: "telegram",
-        sessionKey: "main",
-        to: "telegram:123",
-        body: "see doc",
-        messageId: "mux-doc-1",
-        openclawId: OPENCLAW_ID,
-        attachments: [
-          {
-            type: "application",
-            mimeType: "application/pdf",
-            fileName: "report.pdf",
-            url: "http://mux.local/v1/mux/files/telegram?fileId=abc123",
-          },
-        ],
-      },
-    });
-    const res = createResponse();
-    expect(await handleMuxInboundHttpRequest(req, res)).toBe(true);
-    expect(res.statusCode).toBe(202);
+      const req = createRequest({
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+          "x-openclaw-id": OPENCLAW_ID,
+        },
+        body: {
+          channel: "telegram",
+          sessionKey: "main",
+          to: "telegram:123",
+          body: "see doc",
+          messageId: "mux-doc-1",
+          openclawId: OPENCLAW_ID,
+          attachments: [
+            {
+              type: "application",
+              mimeType: "application/pdf",
+              fileName: "report.pdf",
+              url: "http://mux.local/v1/mux/files/telegram?fileId=abc123",
+            },
+          ],
+        },
+      });
+      const res = createResponse();
+      expect(await handleMuxInboundHttpRequest(req, res)).toBe(true);
+      expect(res.statusCode).toBe(202);
 
-    await waitForAsyncDispatch();
-    expect(mocks.fetchMuxFileStream).toHaveBeenCalledTimes(1);
-    expect(mocks.fetchMuxFileStream).toHaveBeenCalledWith({
-      cfg: expect.any(Object),
-      url: "http://mux.local/v1/mux/files/telegram?fileId=abc123",
+      await waitForAsyncDispatch();
+      expect(mocks.fetchMuxFileStream).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchMuxFileStream).toHaveBeenCalledWith({
+        cfg: expect.any(Object),
+        url: "http://mux.local/v1/mux/files/telegram?fileId=abc123",
+      });
+      expect(mocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      const call = mocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0] as
+        | {
+            ctx?: {
+              MediaPaths?: string[];
+              MediaTypes?: string[];
+              MediaPath?: string;
+              MediaType?: string;
+            };
+          }
+        | undefined;
+      expect(call?.ctx?.MediaPaths).toHaveLength(1);
+      expect(call?.ctx?.MediaTypes).toEqual(["application/pdf"]);
+      expect(call?.ctx?.MediaPath).toBeDefined();
+      expect(call?.ctx?.MediaType).toBe("application/pdf");
+      expect(call?.ctx?.MediaPath).toContain(`${path.sep}media${path.sep}inbound${path.sep}`);
+      expect(fs.existsSync(call?.ctx?.MediaPath ?? "")).toBe(true);
     });
-    expect(mocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
-    const call = mocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0] as
-      | {
-          ctx?: {
-            MediaPaths?: string[];
-            MediaTypes?: string[];
-            MediaPath?: string;
-            MediaType?: string;
-          };
-        }
-      | undefined;
-    expect(call?.ctx?.MediaPaths).toHaveLength(1);
-    expect(call?.ctx?.MediaTypes).toEqual(["application/pdf"]);
-    expect(call?.ctx?.MediaPath).toBeDefined();
-    expect(call?.ctx?.MediaType).toBe("application/pdf");
   });
 
   test("acks immediately without waiting for slow dispatch completion", async () => {

--- a/src/gateway/mux-http.ts
+++ b/src/gateway/mux-http.ts
@@ -59,7 +59,7 @@ import {
   type DiscordGuildEntryResolved,
 } from "../discord/monitor/allow-list.js";
 import { logVerbose, warn } from "../globals.js";
-import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { saveMediaBuffer } from "../media/store.js";
 import {
   addChannelAllowFromStoreEntry,
   readChannelAllowFromStore,
@@ -1206,26 +1206,29 @@ function inferExtFromMime(mime: string | undefined): string {
   return "";
 }
 
-async function resolveAttachmentToTempFile(params: {
+async function resolveAttachmentToStoredFile(params: {
   attachment: MuxInboundAttachment;
   cfg: OpenClawConfig;
-  tmpDir: string;
   index: number;
 }): Promise<{ path: string; mimeType: string } | null> {
-  const { attachment, cfg, tmpDir, index } = params;
-  const ext = inferExtFromMime(attachment.mimeType) || path.extname(attachment.fileName || "");
-  const baseName = attachment.fileName
-    ? path.basename(attachment.fileName, path.extname(attachment.fileName))
-    : `mux-att-${index}`;
-  const tmpPath = path.join(tmpDir, `${baseName}-${index}${ext}`);
+  const { attachment, cfg, index } = params;
   const mimeType = attachment.mimeType || "application/octet-stream";
+  const originalFileName = attachment.fileName?.trim()
+    ? attachment.fileName
+    : `mux-att-${index}${inferExtFromMime(attachment.mimeType) || ""}`;
 
   if (attachment.url) {
     try {
       const response = await fetchMuxFileStream({ cfg, url: attachment.url });
       const buffer = Buffer.from(await response.arrayBuffer());
-      fs.writeFileSync(tmpPath, buffer);
-      return { path: tmpPath, mimeType };
+      const saved = await saveMediaBuffer(
+        buffer,
+        mimeType,
+        "inbound",
+        undefined,
+        originalFileName,
+      );
+      return { path: saved.path, mimeType: saved.contentType ?? mimeType };
     } catch {
       return null;
     }
@@ -1238,8 +1241,14 @@ async function resolveAttachmentToTempFile(params: {
       if (buffer.byteLength === 0) {
         return null;
       }
-      fs.writeFileSync(tmpPath, buffer);
-      return { path: tmpPath, mimeType };
+      const saved = await saveMediaBuffer(
+        buffer,
+        mimeType,
+        "inbound",
+        undefined,
+        originalFileName,
+      );
+      return { path: saved.path, mimeType: saved.contentType ?? mimeType };
     } catch {
       return null;
     }
@@ -1431,7 +1440,6 @@ export async function handleMuxInboundHttpRequest(
   };
 
   const dispatchPromise = (async () => {
-    let tmpDir: string | undefined;
     try {
       await bootstrapMuxPairedSender({
         channel,
@@ -1484,12 +1492,12 @@ export async function handleMuxInboundHttpRequest(
         }
       }
 
-      // Resolve attachments to temp files (same pattern as vanilla TG channel).
+      // Persist inbound attachments in the media store so later tool calls and
+      // follow-up turns can still access the same files.
       if (attachments.length > 0) {
-        tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "mux-att-"));
         const resolved = await Promise.all(
           attachments.map((att, i) =>
-            resolveAttachmentToTempFile({ attachment: att, cfg, tmpDir: tmpDir!, index: i }),
+            resolveAttachmentToStoredFile({ attachment: att, cfg, index: i }),
           ),
         );
         const mediaPaths: string[] = [];
@@ -1580,15 +1588,6 @@ export async function handleMuxInboundHttpRequest(
       }
     } catch (err) {
       warn(`mux inbound attachment resolve failed messageId=${messageId}: ${String(err)}`);
-    } finally {
-      // Clean up temp files.
-      if (tmpDir) {
-        try {
-          fs.rmSync(tmpDir, { recursive: true, force: true });
-        } catch {
-          // Best-effort cleanup.
-        }
-      }
     }
   })();
 


### PR DESCRIPTION
## Summary
- persist mux inbound attachments in the media store instead of a request-scoped temp dir
- keep `ctx.MediaPath` and `MediaPaths` pointed at stable `media/inbound` files for later tool calls and follow-up turns
- update mux HTTP tests to assert the stored files survive after dispatch

## Why
Mux ingress was deleting request-scoped attachment paths after dispatch. Later turns could still contain `[media attached: ...]` notes pointing at those paths, and tool calls like `read` would fail with `ENOENT`, causing image understanding to break.

## Verification
- `pnpm exec vitest run src/gateway/mux-http.test.ts --reporter verbose`
- `pnpm build`
- `HOST_MUX_PORT=28891 HOST_OPENCLAW_PORT=28789 MUX_BASE_URL=http://127.0.0.1:28891 bash phala-deploy/local-mux-e2e/scripts/e2e-telegram.sh`
  - result: `14/14 passed`
  - photo step passed on the live stack after the fix
