### PR TITLE
Security: allow Clawdi-managed audit warning suppression

### DIFF
--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -892,6 +892,33 @@ description: test skill
     expect(res.findings.some((f) => f.checkId === "fs.config.perms_group_readable")).toBe(false);
   });
 
+  it("suppresses state-dir symlink warning when clawdi audit bypass is enabled", async () => {
+    if (isWindows) {
+      return;
+    }
+
+    const tmp = await makeTmpDir("state-symlink");
+    const targetStateDir = path.join(tmp, "state-target");
+    await fs.mkdir(targetStateDir, { recursive: true, mode: 0o700 });
+    const stateDir = path.join(tmp, "state-link");
+    await fs.symlink(targetStateDir, stateDir);
+
+    const configPath = path.join(targetStateDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}\n", "utf-8");
+
+    const res = await runSecurityAudit({
+      config: {},
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+      stateDir,
+      configPath,
+      env: { CLAWDI_AUDIT_IGNORE_WARNING_SAFE: "1" },
+      execDockerRawFn: execDockerRawUnavailable,
+    });
+
+    expectNoFinding(res, "fs.state_dir.symlink");
+  });
+
   it("warns when workspace skill files resolve outside workspace root", async () => {
     if (isWindows) {
       return;
@@ -1423,6 +1450,24 @@ description: test skill
           detail: expect.stringContaining("gateway.controlUi.dangerouslyDisableDeviceAuth=true"),
         }),
       ]),
+    );
+  });
+
+  it("suppresses managed-deployment device-auth warning when clawdi audit bypass is enabled", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        controlUi: { dangerouslyDisableDeviceAuth: true },
+      },
+    };
+
+    const res = await audit(cfg, {
+      env: { CLAWDI_AUDIT_IGNORE_WARNING_SAFE: "1" },
+    });
+
+    expectNoFinding(res, "gateway.control_ui.device_auth_disabled");
+    const flags = res.findings.find((f) => f.checkId === "config.insecure_or_dangerous_flags");
+    expect(flags?.detail ?? "").not.toContain(
+      "gateway.controlUi.dangerouslyDisableDeviceAuth=true",
     );
   });
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -13,6 +13,7 @@ import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveGatewayProbeAuthSafe } from "../gateway/probe-auth.js";
 import { probeGateway } from "../gateway/probe.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   listInterpreterLikeSafeBins,
   resolveMergedSafeBinProfileFixtures,
@@ -131,6 +132,10 @@ type AuditExecutionContext = {
   codeSafetySummaryCache: Map<string, Promise<unknown>>;
 };
 
+function shouldIgnoreClawdiManagedSafeWarnings(env: NodeJS.ProcessEnv | undefined): boolean {
+  return isTruthyEnvValue(env?.CLAWDI_AUDIT_IGNORE_WARNING_SAFE);
+}
+
 function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary {
   let critical = 0;
   let warn = 0;
@@ -213,6 +218,7 @@ async function collectFilesystemFindings(params: {
   execIcacls?: ExecFn;
 }): Promise<SecurityAuditFinding[]> {
   const findings: SecurityAuditFinding[] = [];
+  const ignoreClawdiManagedSafeWarnings = shouldIgnoreClawdiManagedSafeWarnings(params.env);
 
   const stateDirPerms = await inspectPathPermissions(params.stateDir, {
     env: params.env,
@@ -220,7 +226,7 @@ async function collectFilesystemFindings(params: {
     exec: params.execIcacls,
   });
   if (stateDirPerms.ok) {
-    if (stateDirPerms.isSymlink) {
+    if (stateDirPerms.isSymlink && !ignoreClawdiManagedSafeWarnings) {
       findings.push({
         checkId: "fs.state_dir.symlink",
         severity: "warn",
@@ -341,6 +347,7 @@ function collectGatewayConfigFindings(
   env: NodeJS.ProcessEnv,
 ): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
+  const ignoreClawdiManagedSafeWarnings = shouldIgnoreClawdiManagedSafeWarnings(env);
 
   const bind = typeof cfg.gateway?.bind === "string" ? cfg.gateway.bind : "loopback";
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
@@ -565,7 +572,10 @@ function collectGatewayConfigFindings(
     });
   }
 
-  if (cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true) {
+  if (
+    cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true &&
+    !ignoreClawdiManagedSafeWarnings
+  ) {
     findings.push({
       checkId: "gateway.control_ui.device_auth_disabled",
       severity: "critical",
@@ -588,7 +598,11 @@ function collectGatewayConfigFindings(
     });
   }
 
-  const enabledDangerousFlags = collectEnabledInsecureOrDangerousFlags(cfg);
+  const enabledDangerousFlags = collectEnabledInsecureOrDangerousFlags(cfg).filter((flag) =>
+    ignoreClawdiManagedSafeWarnings
+      ? flag !== "gateway.controlUi.dangerouslyDisableDeviceAuth=true"
+      : true,
+  );
   if (enabledDangerousFlags.length > 0) {
     findings.push({
       checkId: "config.insecure_or_dangerous_flags",


### PR DESCRIPTION
## Summary
- add a Clawdi-specific audit bypass for warnings that are intentional in managed Phala deployments
- suppress the state-dir symlink warning and the Control UI device-auth-disabled warning when `CLAWDI_AUDIT_IGNORE_WARNING_SAFE=1`
- keep the behavior covered with focused security-audit tests

## Notes
- this is intentionally fork-specific and targets the Phala branch
- it does not change the default upstream audit behavior

## Verification
- pnpm exec vitest run src/security/audit.test.ts -t "symlink warning when clawdi audit bypass is enabled|managed-deployment device-auth warning when clawdi audit bypass is enabled" --reporter verbose
