### PR TITLE
Infra: restore MASTER_KEY device identity derivation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.3.13-phala.2",
+  "version": "2026.3.13-phala.3",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 
 describe("device identity state dir defaults", () => {
@@ -68,6 +69,20 @@ describe("device identity state dir defaults", () => {
       expect(stored.deviceId).toBe(regenerated.deviceId);
       expect(stored.publicKeyPem).toBe(regenerated.publicKeyPem);
       expect(stored.privateKeyPem).toBe(regenerated.privateKeyPem);
+    });
+  });
+
+  it("recreates the same identity after device.json loss when MASTER_KEY is set", async () => {
+    await withStateDirEnv("openclaw-identity-state-", async ({ stateDir }) => {
+      await withEnvAsync({ MASTER_KEY: "state-dir-master-key" }, async () => {
+        const identityPath = path.join(stateDir, "identity", "device.json");
+        const first = loadOrCreateDeviceIdentity();
+
+        await fs.rm(identityPath, { force: true });
+
+        const recreated = loadOrCreateDeviceIdentity();
+        expect(recreated).toEqual(first);
+      });
     });
   });
 });

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   deriveDeviceIdFromPublicKey,
@@ -56,6 +57,24 @@ describe("device identity crypto helpers", () => {
       expect(deriveDeviceIdFromPublicKey("%%%")).toBeNull();
       expect(verifyDeviceSignature("%%%invalid%%%", payload, signature)).toBe(false);
       expect(verifyDeviceSignature(identity.publicKeyPem, payload, "%%%invalid%%%")).toBe(false);
+    });
+  });
+
+  it("derives a stable identity from MASTER_KEY on first create", async () => {
+    await withTempDir("openclaw-device-identity-", async (dir) => {
+      const identityPath = path.join(dir, "device.json");
+
+      await withEnvAsync({ MASTER_KEY: "test-master-key" }, async () => {
+        const first = loadOrCreateDeviceIdentity(identityPath);
+        const second = loadOrCreateDeviceIdentity(identityPath);
+
+        expect(second).toEqual(first);
+      });
+
+      await withEnvAsync({ MASTER_KEY: "test-master-key" }, async () => {
+        const third = loadOrCreateDeviceIdentity(identityPath);
+        expect(third).toEqual(loadOrCreateDeviceIdentity(identityPath));
+      });
     });
   });
 });

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -26,6 +26,8 @@ function ensureDir(filePath: string) {
 }
 
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const ED25519_PKCS8_SEED_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const DEVICE_IDENTITY_MASTER_KEY_INFO = "openclaw-device-identity-v1";
 
 function base64UrlEncode(buf: Buffer): string {
   return buf.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
@@ -56,6 +58,21 @@ function fingerprintPublicKey(publicKeyPem: string): string {
 
 function generateIdentity(): DeviceIdentity {
   const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const deviceId = fingerprintPublicKey(publicKeyPem);
+  return { deviceId, publicKeyPem, privateKeyPem };
+}
+
+function deriveIdentityFromMasterKey(masterKey: string): DeviceIdentity {
+  // Keep Phala-style deployments stable across first boot and accidental
+  // device.json loss when MASTER_KEY is operator-managed and persistent.
+  const seed = Buffer.from(
+    crypto.hkdfSync("sha256", masterKey, "", DEVICE_IDENTITY_MASTER_KEY_INFO, 32),
+  );
+  const pkcs8 = Buffer.concat([ED25519_PKCS8_SEED_PREFIX, seed]);
+  const privateKey = crypto.createPrivateKey({ key: pkcs8, format: "der", type: "pkcs8" });
+  const publicKey = crypto.createPublicKey(privateKey);
   const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
   const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
   const deviceId = fingerprintPublicKey(publicKeyPem);
@@ -104,7 +121,8 @@ export function loadOrCreateDeviceIdentity(
     // fall through to regenerate
   }
 
-  const identity = generateIdentity();
+  const masterKey = typeof process.env.MASTER_KEY === "string" ? process.env.MASTER_KEY.trim() : "";
+  const identity = masterKey ? deriveIdentityFromMasterKey(masterKey) : generateIdentity();
   ensureDir(filePath);
   const stored: StoredIdentity = {
     version: 1,


### PR DESCRIPTION
## Summary
- restore deterministic device identity creation from `MASTER_KEY`
- preserve existing stored identities, but recreate the old stable identity on first boot or after `device.json` loss
- bump the branch version to `2026.3.13-phala.3`

## Verification
- pnpm exec vitest run src/infra/device-identity.test.ts src/infra/device-identity.state-dir.test.ts --reporter verbose
- pnpm build
