### PR TITLE
CI: fall back to GITHUB_TOKEN in forks

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  HAS_GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY != "" && 'true' || 'false' }}
+  HAS_GH_APP_PRIVATE_KEY_FALLBACK: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK != "" && 'true' || 'false' }}
 
 permissions: {}
 
@@ -22,14 +24,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
+        if: steps.app-token.outcome != 'success' && env.HAS_GH_APP_PRIVATE_KEY_FALLBACK == 'true'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}

--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -22,20 +22,21 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: steps.app-token.outcome == 'failure'
+        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - name: Handle labeled items
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             // Labels prefixed with "r:" are auto-response triggers.
             const activePrLimit = 10;

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,25 +30,26 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: steps.app-token.outcome == 'failure'
+        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           sync-labels: true
       - name: Apply PR size label
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -137,7 +138,7 @@ jobs:
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const login = context.payload.pull_request?.user?.login;
             if (!login) {
@@ -208,7 +209,7 @@ jobs:
       - name: Apply too-many-prs label
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -386,20 +387,21 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: steps.app-token.outcome == 'failure'
+        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - name: Backfill PR labels
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -634,20 +636,21 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: steps.app-token.outcome == 'failure'
+        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const login = context.payload.issue?.user?.login;
             if (!login) {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,6 +18,8 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  HAS_GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY != "" && 'true' || 'false' }}
+  HAS_GH_APP_PRIVATE_KEY_FALLBACK: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK != "" && 'true' || 'false' }}
 
 permissions: {}
 
@@ -30,14 +32,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
+        if: steps.app-token.outcome != 'success' && env.HAS_GH_APP_PRIVATE_KEY_FALLBACK == 'true'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
@@ -387,14 +389,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
+        if: steps.app-token.outcome != 'success' && env.HAS_GH_APP_PRIVATE_KEY_FALLBACK == 'true'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
@@ -636,14 +638,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
+        if: steps.app-token.outcome != 'success' && env.HAS_GH_APP_PRIVATE_KEY_FALLBACK == 'true'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  HAS_GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY != "" && 'true' || 'false' }}
+  HAS_GH_APP_PRIVATE_KEY_FALLBACK: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK != "" && 'true' || 'false' }}
 
 permissions: {}
 
@@ -19,14 +21,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
-        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
+        if: steps.app-token.outcome != 'success' && env.HAS_GH_APP_PRIVATE_KEY_FALLBACK == 'true'
         continue-on-error: true
         with:
           app-id: "2971289"
@@ -128,7 +130,7 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
-        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_GH_APP_PRIVATE_KEY == 'true'
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,12 +19,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v2
         id: app-token-fallback
+        if: ${{ steps.app-token.outcome != 'success' && secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' }}
         continue-on-error: true
         with:
           app-id: "2971289"
@@ -34,7 +36,7 @@ jobs:
         continue-on-error: true
         uses: actions/stale@v10
         with:
-          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           days-before-issue-stale: 7
           days-before-issue-close: 5
           days-before-pr-stale: 5
@@ -67,7 +69,7 @@ jobs:
         if: always()
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token-fallback.outputs.token || steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token-fallback.outputs.token || steps.app-token.outputs.token || github.token }}
           script: |
             const cacheKey = "_state";
             const { owner, repo } = context.repo;
@@ -126,13 +128,14 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Lock closed issues after 48h of no comments
         uses: actions/github-script@v8
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const lockAfterHours = 48;
             const lockAfterMs = lockAfterHours * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- skip GitHub App token creation when fork secrets are missing
- fall back to `github.token` in labeler, auto-response, and stale workflows
- keep the GitHub App path preferred when the secrets are configured

## Testing
- inspected failing Actions run 23380264307 and confirmed `actions/create-github-app-token@v2` was failing because `privateKey` was missing in the fork
- not run locally (workflow-only changes)
