### PR TITLE
docs(skill): clarify Composio MCP account model

### DIFF
--- a/skills/composio/SKILL.md
+++ b/skills/composio/SKILL.md
@@ -128,7 +128,6 @@ Use exact tool slugs and argument names from search results.
 ## Google Services
 
 Google routing is inconsistent. Do not assume `googlesuper` covers every Google task.
-
 When speaking to normal users:
 
 - Treat this as "Google" from the user's perspective.

--- a/skills/composio/SKILL.md
+++ b/skills/composio/SKILL.md
@@ -81,6 +81,17 @@ The response includes:
 - `tool_schemas`
 - `recommended_plan_steps`
 - `known_pitfalls`
+- a short workflow `session.id`; pass it to later meta-tool calls when provided
+
+### Connection model
+
+Use this skill as toolkit-level connection management.
+
+- Assume one usable active account per toolkit from MCP's perspective.
+- Unless the execution tool schema explicitly exposes account switching, do not tell the user they can choose between multiple accounts for the same toolkit through MCP. Google toolkits do not support account switching.
+- `COMPOSIO_MANAGE_CONNECTIONS` is for checking, connecting, or reconnecting toolkits, not for selecting individual accounts.
+- If a toolkit is already active, calling `COMPOSIO_MANAGE_CONNECTIONS` again usually returns the existing active connection instead of a second-account OAuth link.
+- If the user explicitly wants to switch the active account for a toolkit, reconnect that toolkit with `reinitiate_all=true` and explain that MCP will reconnect the toolkit rather than let them pick from multiple existing accounts.
 
 ### 2. Connect services if needed
 
@@ -88,10 +99,21 @@ If `has_active_connection` is false for a toolkit:
 
 ```bash
 mcporter call clawdi-mcp.COMPOSIO_MANAGE_CONNECTIONS \
-  'toolkits=["<exact-toolkit-from-search>"]'
+  'toolkits=["<exact-toolkit-from-search>"]' \
+  'session_id="star"'
 ```
 
 This returns a `redirect_url`. Share that link with the user so they can complete OAuth.
+
+If `has_active_connection` is true, do not try to use `COMPOSIO_MANAGE_CONNECTIONS` to add a second account for that same toolkit. MCP generally treats the toolkit as already connected. If the user explicitly wants to replace or refresh the active account, use:
+
+```bash
+mcporter call clawdi-mcp.COMPOSIO_MANAGE_CONNECTIONS \
+  'toolkits=["gmail"]' \
+  'reinitiate_all=true'
+```
+
+Explain clearly that MCP will reconnect the toolkit, not let the user pick between multiple existing accounts.
 
 ### 3. Execute tools
 
@@ -142,6 +164,7 @@ Download the file locally, then process it.
 
 - Search first. Do not guess tool names.
 - Check connection status before executing and use the exact toolkit names returned by search.
+- If the user asks to connect a second account for the same toolkit, warn that MCP is single-account-oriented from the agent's perspective and cannot target a specific account unless the execution schema explicitly supports switching.
 - Use `recommended_plan_steps`.
 - Read `known_pitfalls`.
 - Loop on pagination when `has_more` is true.


### PR DESCRIPTION
## Summary

- Problem: the Composio skill did not tell agents how MCP actually behaves when a toolkit is already connected or when users ask about multiple accounts.
- Why it matters: agents could promise account selection or second-account flows that the verified MCP surface does not expose.
- What changed: updated `skills/composio/SKILL.md` to make the MCP account model explicit, self-contained, and operational for agents.
- What did NOT change (scope boundary): no product code, backend behavior, or runtime MCP implementation changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #101

## User-visible / Behavior Changes

None. This only changes agent guidance inside the Composio skill.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: Codex GPT-5 agent workflow
- Integration/channel (if any): Composio MCP skill docs
- Relevant config (redacted): none

### Steps

1. Read the existing `skills/composio/SKILL.md` content.
2. Compare it against verified live MCP behavior for Gmail/Google toolkit connections.
3. Update the skill so the guidance is self-contained and matches the observed MCP account model.

### Expected

- Skill tells agents how to handle toolkit connection state, reconnect flows, and lack of account switching in MCP.

### Actual

- Skill now explicitly treats Composio MCP as toolkit-level from the agent perspective and warns against promising per-account switching unless a tool schema explicitly supports it.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the final skill text against live Composio MCP behavior previously reproduced for single-account Gmail, repeated connect calls, and schema inspection.
- Edge cases checked: wording now stays MCP-only and no longer instructs agents to use non-MCP account-selection paths.
- What you did **not** verify: no automated tests or runtime product flows were changed in this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or the three skill-doc commits on the branch.
- Files/config to restore: `skills/composio/SKILL.md`
- Known bad symptoms reviewers should watch for: agents may still promise unsupported multi-account behavior if wording is ambiguous.

## Risks and Mitigations

- Risk: the documented MCP account model could still evolve upstream.
  - Mitigation: wording is limited to currently verified behavior and avoids broader claims like guaranteed deletion of old connections.
