### PR TITLE
mux-server: recover WhatsApp queued inbound delivery after re-registration

### DIFF
--- a/mux-server/README.md
+++ b/mux-server/README.md
@@ -121,7 +121,7 @@ node --import tsx mux-server/src/server.ts
 - `MUX_WHATSAPP_QUEUE_RETRY_INITIAL_MS` (default `1000`): initial retry backoff for queued WhatsApp inbound deliveries.
 - `MUX_WHATSAPP_QUEUE_RETRY_MAX_MS` (default `60000`): max retry backoff for queued WhatsApp inbound deliveries.
 - `MUX_WHATSAPP_QUEUE_BATCH_SIZE` (default `20`): max number of queued WhatsApp inbound deliveries processed per pass.
-- `MUX_WHATSAPP_QUEUE_MAX_AGE_MS` (default `86400000`): maximum age for queued WhatsApp inbound deliveries before they are explicitly exhausted and dropped.
+- `MUX_WHATSAPP_QUEUE_MAX_AGE_MS` (default `86400000`): maximum delivery-window age for queued WhatsApp inbound deliveries before they are explicitly exhausted and dropped; the window resets when the tenant re-registers, even if the inbound URL stays the same.
 - `MUX_TELEGRAM_BOT_USERNAME` (optional): enables Telegram deep link in pairing-token response.
 - `MUX_PAIRING_TOKEN_TTL_SEC` (default `900`): default one-time pairing-token TTL in seconds.
 - `MUX_PAIRING_TOKEN_MAX_TTL_SEC` (default `3600`): max allowed one-time pairing-token TTL.

--- a/mux-server/README.md
+++ b/mux-server/README.md
@@ -117,6 +117,11 @@ node --import tsx mux-server/src/server.ts
 - `MUX_WHATSAPP_AUTH_DIR` (optional): WhatsApp auth directory; defaults to OpenClaw's default web auth dir.
 - `MUX_WHATSAPP_INBOUND_MEDIA_MAX_BYTES` (default `5000000`): max file size for WhatsApp inbound media attachments (all types: images, documents, video, audio).
 - `MUX_WHATSAPP_INBOUND_RETRY_MS` (default `1000`): reconnect backoff when WhatsApp listener closes.
+- `MUX_WHATSAPP_QUEUE_POLL_MS` (default `500`): poll interval for the persisted WhatsApp inbound delivery queue.
+- `MUX_WHATSAPP_QUEUE_RETRY_INITIAL_MS` (default `1000`): initial retry backoff for queued WhatsApp inbound deliveries.
+- `MUX_WHATSAPP_QUEUE_RETRY_MAX_MS` (default `60000`): max retry backoff for queued WhatsApp inbound deliveries.
+- `MUX_WHATSAPP_QUEUE_BATCH_SIZE` (default `20`): max number of queued WhatsApp inbound deliveries processed per pass.
+- `MUX_WHATSAPP_QUEUE_MAX_AGE_MS` (default `86400000`): maximum age for queued WhatsApp inbound deliveries before they are explicitly exhausted and dropped.
 - `MUX_TELEGRAM_BOT_USERNAME` (optional): enables Telegram deep link in pairing-token response.
 - `MUX_PAIRING_TOKEN_TTL_SEC` (default `900`): default one-time pairing-token TTL in seconds.
 - `MUX_PAIRING_TOKEN_MAX_TTL_SEC` (default `3600`): max allowed one-time pairing-token TTL.

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -33,6 +33,12 @@ import {
 } from "./observability/snapshot.js";
 import { createInboundTraceId } from "./observability/tracing.js";
 import { createRuntimeJwtSigner, hasScope } from "./runtime-jwt.js";
+import {
+  WhatsAppInboundDeliveryError,
+  classifyWhatsAppInboundDeliveryError,
+  isRetryableWhatsAppInboundStatus,
+  resolveWhatsAppInboundQueueRetryState,
+} from "./whatsapp-inbound-queue.js";
 
 type SendResult = {
   statusCode: number;
@@ -5358,60 +5364,6 @@ function computeWhatsAppQueueRetryDelayMs(attemptCount: number): number {
   return Math.min(maxDelay, delay);
 }
 
-class WhatsAppInboundDeliveryError extends Error {
-  retryable: boolean;
-  statusCode: number | null;
-  targetUpdatedAtMs: number | null;
-
-  constructor(
-    message: string,
-    options: {
-      retryable: boolean;
-      statusCode?: number | null;
-      targetUpdatedAtMs?: number | null;
-      cause?: unknown;
-    },
-  ) {
-    super(message, "cause" in options ? { cause: options.cause } : undefined);
-    this.name = "WhatsAppInboundDeliveryError";
-    this.retryable = options.retryable;
-    this.statusCode =
-      typeof options.statusCode === "number" && Number.isFinite(options.statusCode)
-        ? Math.trunc(options.statusCode)
-        : null;
-    this.targetUpdatedAtMs =
-      typeof options.targetUpdatedAtMs === "number" && Number.isFinite(options.targetUpdatedAtMs)
-        ? Math.trunc(options.targetUpdatedAtMs)
-        : null;
-  }
-}
-
-function isRetryableWhatsAppInboundStatus(statusCode: number): boolean {
-  return statusCode === 408 || statusCode === 425 || statusCode === 429 || statusCode >= 500;
-}
-
-function classifyWhatsAppInboundDeliveryError(error: unknown): {
-  retryable: boolean;
-  statusCode: number | null;
-  targetUpdatedAtMs: number | null;
-  errorMessage: string;
-} {
-  if (error instanceof WhatsAppInboundDeliveryError) {
-    return {
-      retryable: error.retryable,
-      statusCode: error.statusCode,
-      targetUpdatedAtMs: error.targetUpdatedAtMs,
-      errorMessage: errorString(error),
-    };
-  }
-  return {
-    retryable: true,
-    statusCode: null,
-    targetUpdatedAtMs: null,
-    errorMessage: errorString(error),
-  };
-}
-
 function snapshotWhatsAppInboundMessage(message: WebInboundMessage): WebInboundMessage {
   return {
     id: readNonEmptyString(message.id) ?? undefined,
@@ -7700,34 +7652,15 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         messageId: message.id ?? null,
       });
     } catch (error) {
-      const failure = classifyWhatsAppInboundDeliveryError(error);
-      const attemptCount = Math.max(
-        1,
-        Number.isFinite(row.attempt_count) ? Math.trunc(row.attempt_count) + 1 : 1,
-      );
-      const createdAtMs =
-        Number.isFinite(row.created_at_ms) && row.created_at_ms > 0
-          ? Math.trunc(row.created_at_ms)
-          : now;
-      let deliveryWindowStartedAtMs =
-        Number.isFinite(row.delivery_window_started_at_ms) && row.delivery_window_started_at_ms > 0
-          ? Math.trunc(row.delivery_window_started_at_ms)
-          : createdAtMs;
-      let lastTargetUpdateAtMs =
-        Number.isFinite(row.last_target_update_at_ms) && row.last_target_update_at_ms > 0
-          ? Math.trunc(row.last_target_update_at_ms)
-          : 0;
-      const targetUpdatedAtMs =
-        Number.isFinite(failure.targetUpdatedAtMs) && (failure.targetUpdatedAtMs ?? 0) > 0
-          ? Math.trunc(failure.targetUpdatedAtMs ?? 0)
-          : 0;
-      if (targetUpdatedAtMs > lastTargetUpdateAtMs) {
-        deliveryWindowStartedAtMs = now;
-        lastTargetUpdateAtMs = targetUpdatedAtMs;
-      }
-      const ageMs = Math.max(0, now - deliveryWindowStartedAtMs);
+      const failure = classifyWhatsAppInboundDeliveryError(error, errorString);
       const maxAgeMs = Math.max(1_000, Math.trunc(whatsappQueueMaxAgeMs));
-      if (!failure.retryable || ageMs >= maxAgeMs) {
+      const retryState = resolveWhatsAppInboundQueueRetryState({
+        row,
+        now,
+        maxAgeMs,
+        failure,
+      });
+      if (retryState.exhausted) {
         stmtDeleteWhatsAppInboundQueueById.run(row.id);
         metrics.recordInboundEvent("whatsapp", "dropped");
         log({
@@ -7735,8 +7668,8 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
           queueId: row.id,
           dedupeKey: row.dedupe_key,
           messageId: message.id ?? null,
-          attemptCount,
-          ageMs,
+          attemptCount: retryState.attemptCount,
+          ageMs: retryState.ageMs,
           maxAgeMs,
           retryable: failure.retryable,
           statusCode: failure.statusCode,
@@ -7745,15 +7678,15 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         continue;
       }
 
-      const retryDelayMs = computeWhatsAppQueueRetryDelayMs(attemptCount);
+      const retryDelayMs = computeWhatsAppQueueRetryDelayMs(retryState.attemptCount);
       const nextAttemptAtMs = Date.now() + retryDelayMs;
       stmtDeferWhatsAppInboundQueueById.run(
         nextAttemptAtMs,
-        attemptCount,
+        retryState.attemptCount,
         failure.errorMessage.slice(0, 2_000),
         Date.now(),
-        deliveryWindowStartedAtMs,
-        lastTargetUpdateAtMs,
+        retryState.deliveryWindowStartedAtMs,
+        retryState.lastTargetUpdateAtMs,
         row.id,
       );
       log({
@@ -7761,7 +7694,7 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         queueId: row.id,
         dedupeKey: row.dedupe_key,
         messageId: message.id ?? null,
-        attemptCount,
+        attemptCount: retryState.attemptCount,
         retryDelayMs,
         nextAttemptAtMs,
         error: failure.errorMessage,

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -133,6 +133,8 @@ type WhatsAppInboundQueueRow = {
   payload_json: string;
   attempt_count: number;
   created_at_ms: number;
+  delivery_window_started_at_ms: number;
+  last_target_update_at_ms: number;
 };
 
 type TelegramBoundRoute = {
@@ -179,6 +181,7 @@ type TenantInboundTarget = {
   url: string;
   timeoutMs: number;
   openclawId: string;
+  updatedAtMs: number | null;
 };
 
 type WebInboundMessage = {
@@ -775,7 +778,7 @@ const stmtUpsertTenantInboundTargetByAdmin = db.prepare(`
 `);
 
 const stmtSelectTenantInboundTargetById = db.prepare(`
-  SELECT inbound_url, inbound_token, inbound_timeout_ms
+  SELECT inbound_url, inbound_token, inbound_timeout_ms, updated_at_ms
   FROM tenants
   WHERE id = ? AND status = 'active'
   LIMIT 1
@@ -1066,15 +1069,24 @@ const stmtInsertWhatsAppInboundQueue = db.prepare(`
     next_attempt_at_ms,
     attempt_count,
     last_error,
+    delivery_window_started_at_ms,
+    last_target_update_at_ms,
     created_at_ms,
     updated_at_ms
   )
-  VALUES (?, ?, ?, 0, NULL, ?, ?)
+  VALUES (?, ?, ?, 0, NULL, ?, 0, ?, ?)
   ON CONFLICT(dedupe_key) DO NOTHING
 `);
 
 const stmtSelectDueWhatsAppInboundQueue = db.prepare(`
-  SELECT id, dedupe_key, payload_json, attempt_count, created_at_ms
+  SELECT
+    id,
+    dedupe_key,
+    payload_json,
+    attempt_count,
+    created_at_ms,
+    delivery_window_started_at_ms,
+    last_target_update_at_ms
   FROM whatsapp_inbound_queue
   WHERE next_attempt_at_ms <= ?
   ORDER BY id ASC
@@ -1092,7 +1104,9 @@ const stmtDeferWhatsAppInboundQueueById = db.prepare(`
     next_attempt_at_ms = ?,
     attempt_count = ?,
     last_error = ?,
-    updated_at_ms = ?
+    updated_at_ms = ?,
+    delivery_window_started_at_ms = ?,
+    last_target_update_at_ms = ?
   WHERE id = ?
 `);
 
@@ -1263,6 +1277,7 @@ function resolveTenantInboundTarget(tenantId: string): TenantInboundTarget | nul
     | {
         inbound_url?: unknown;
         inbound_timeout_ms?: unknown;
+        updated_at_ms?: unknown;
       }
     | undefined;
   const url = readNonEmptyString(row?.inbound_url);
@@ -1270,10 +1285,12 @@ function resolveTenantInboundTarget(tenantId: string): TenantInboundTarget | nul
     return null;
   }
   const timeoutMs = readPositiveInt(row?.inbound_timeout_ms) ?? 15_000;
+  const updatedAtMs = readPositiveInt(row?.updated_at_ms) ?? null;
   return {
     url,
     timeoutMs,
     openclawId: tenantId,
+    updatedAtMs,
   };
 }
 
@@ -1666,6 +1683,8 @@ function initializeDatabase(database: DatabaseSync) {
       next_attempt_at_ms INTEGER NOT NULL,
       attempt_count INTEGER NOT NULL DEFAULT 0,
       last_error TEXT,
+      delivery_window_started_at_ms INTEGER NOT NULL,
+      last_target_update_at_ms INTEGER NOT NULL DEFAULT 0,
       created_at_ms INTEGER NOT NULL,
       updated_at_ms INTEGER NOT NULL
     );
@@ -1674,6 +1693,7 @@ function initializeDatabase(database: DatabaseSync) {
   `);
   ensureTenantInboundTargetColumns(database);
   ensurePairingTokenColumns(database);
+  ensureWhatsAppInboundQueueColumns(database);
 }
 
 function ensureTenantInboundTargetColumns(database: DatabaseSync) {
@@ -1723,6 +1743,28 @@ function ensurePairingTokenColumns(database: DatabaseSync) {
       DROP TABLE pairing_tokens_old;
     `);
   }
+}
+
+function ensureWhatsAppInboundQueueColumns(database: DatabaseSync) {
+  const rows = database.prepare("PRAGMA table_info(whatsapp_inbound_queue)").all() as Array<{
+    name?: unknown;
+  }>;
+  const columnNames = new Set(rows.map((row) => (typeof row.name === "string" ? row.name : "")));
+  if (!columnNames.has("delivery_window_started_at_ms")) {
+    database.exec(
+      "ALTER TABLE whatsapp_inbound_queue ADD COLUMN delivery_window_started_at_ms INTEGER NOT NULL DEFAULT 0",
+    );
+  }
+  if (!columnNames.has("last_target_update_at_ms")) {
+    database.exec(
+      "ALTER TABLE whatsapp_inbound_queue ADD COLUMN last_target_update_at_ms INTEGER NOT NULL DEFAULT 0",
+    );
+  }
+  database.exec(`
+    UPDATE whatsapp_inbound_queue
+    SET delivery_window_started_at_ms = created_at_ms
+    WHERE delivery_window_started_at_ms <= 0
+  `);
 }
 
 function seedTenants(database: DatabaseSync, tenants: TenantSeed[]) {
@@ -5319,12 +5361,14 @@ function computeWhatsAppQueueRetryDelayMs(attemptCount: number): number {
 class WhatsAppInboundDeliveryError extends Error {
   retryable: boolean;
   statusCode: number | null;
+  targetUpdatedAtMs: number | null;
 
   constructor(
     message: string,
     options: {
       retryable: boolean;
       statusCode?: number | null;
+      targetUpdatedAtMs?: number | null;
       cause?: unknown;
     },
   ) {
@@ -5334,6 +5378,10 @@ class WhatsAppInboundDeliveryError extends Error {
     this.statusCode =
       typeof options.statusCode === "number" && Number.isFinite(options.statusCode)
         ? Math.trunc(options.statusCode)
+        : null;
+    this.targetUpdatedAtMs =
+      typeof options.targetUpdatedAtMs === "number" && Number.isFinite(options.targetUpdatedAtMs)
+        ? Math.trunc(options.targetUpdatedAtMs)
         : null;
   }
 }
@@ -5345,18 +5393,21 @@ function isRetryableWhatsAppInboundStatus(statusCode: number): boolean {
 function classifyWhatsAppInboundDeliveryError(error: unknown): {
   retryable: boolean;
   statusCode: number | null;
+  targetUpdatedAtMs: number | null;
   errorMessage: string;
 } {
   if (error instanceof WhatsAppInboundDeliveryError) {
     return {
       retryable: error.retryable,
       statusCode: error.statusCode,
+      targetUpdatedAtMs: error.targetUpdatedAtMs,
       errorMessage: errorString(error),
     };
   }
   return {
     retryable: true,
     statusCode: null,
+    targetUpdatedAtMs: null,
     errorMessage: errorString(error),
   };
 }
@@ -5408,6 +5459,7 @@ function enqueueWhatsAppInboundMessage(message: WebInboundMessage): void {
   const insertResult = stmtInsertWhatsAppInboundQueue.run(
     dedupeKey,
     JSON.stringify(snapshot),
+    now,
     now,
     now,
     now,
@@ -7657,7 +7709,23 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         Number.isFinite(row.created_at_ms) && row.created_at_ms > 0
           ? Math.trunc(row.created_at_ms)
           : now;
-      const ageMs = Math.max(0, now - createdAtMs);
+      let deliveryWindowStartedAtMs =
+        Number.isFinite(row.delivery_window_started_at_ms) && row.delivery_window_started_at_ms > 0
+          ? Math.trunc(row.delivery_window_started_at_ms)
+          : createdAtMs;
+      let lastTargetUpdateAtMs =
+        Number.isFinite(row.last_target_update_at_ms) && row.last_target_update_at_ms > 0
+          ? Math.trunc(row.last_target_update_at_ms)
+          : 0;
+      const targetUpdatedAtMs =
+        Number.isFinite(failure.targetUpdatedAtMs) && (failure.targetUpdatedAtMs ?? 0) > 0
+          ? Math.trunc(failure.targetUpdatedAtMs ?? 0)
+          : 0;
+      if (targetUpdatedAtMs > lastTargetUpdateAtMs) {
+        deliveryWindowStartedAtMs = now;
+        lastTargetUpdateAtMs = targetUpdatedAtMs;
+      }
+      const ageMs = Math.max(0, now - deliveryWindowStartedAtMs);
       const maxAgeMs = Math.max(1_000, Math.trunc(whatsappQueueMaxAgeMs));
       if (!failure.retryable || ageMs >= maxAgeMs) {
         stmtDeleteWhatsAppInboundQueueById.run(row.id);
@@ -7684,6 +7752,8 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         attemptCount,
         failure.errorMessage.slice(0, 2_000),
         Date.now(),
+        deliveryWindowStartedAtMs,
+        lastTargetUpdateAtMs,
         row.id,
       );
       log({
@@ -7911,9 +7981,9 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
 
   const target = resolveTenantInboundTarget(binding.tenantId);
   if (!target) {
-    metrics.recordInboundEvent("whatsapp", "dropped");
+    metrics.recordInboundEvent("whatsapp", "error");
     log({
-      type: "whatsapp_inbound_drop_no_target",
+      type: "whatsapp_inbound_deferred_no_target",
       tenantId: binding.tenantId,
       routeKey: binding.routeKey,
       accountId,
@@ -7923,7 +7993,8 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
     throw new WhatsAppInboundDeliveryError(
       `whatsapp inbound target missing for tenant ${binding.tenantId}`,
       {
-        retryable: false,
+        retryable: true,
+        targetUpdatedAtMs: null,
       },
     );
   }
@@ -8024,6 +8095,7 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
     metrics.recordInboundEvent("whatsapp", "error");
     throw new WhatsAppInboundDeliveryError(errorString(error), {
       retryable: true,
+      targetUpdatedAtMs: target.updatedAtMs,
       cause: error,
     });
   }
@@ -8036,6 +8108,7 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
       {
         retryable: isRetryableWhatsAppInboundStatus(response.status),
         statusCode: response.status,
+        targetUpdatedAtMs: target.updatedAtMs,
       },
     );
   }

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -132,6 +132,7 @@ type WhatsAppInboundQueueRow = {
   dedupe_key: string;
   payload_json: string;
   attempt_count: number;
+  created_at_ms: number;
 };
 
 type TelegramBoundRoute = {
@@ -613,6 +614,7 @@ const whatsappQueueRetryInitialMs = Number(
 );
 const whatsappQueueRetryMaxMs = Number(process.env.MUX_WHATSAPP_QUEUE_RETRY_MAX_MS || 60_000);
 const whatsappQueueBatchSize = Number(process.env.MUX_WHATSAPP_QUEUE_BATCH_SIZE || 20);
+const whatsappQueueMaxAgeMs = Number(process.env.MUX_WHATSAPP_QUEUE_MAX_AGE_MS || 24 * 60 * 60_000);
 const pairingTokenTtlSec = Number(process.env.MUX_PAIRING_TOKEN_TTL_SEC || 15 * 60);
 const pairingTokenMaxTtlSec = Number(process.env.MUX_PAIRING_TOKEN_MAX_TTL_SEC || 60 * 60);
 let telegramBotUsername = readNonEmptyString(process.env.MUX_TELEGRAM_BOT_USERNAME);
@@ -1072,7 +1074,7 @@ const stmtInsertWhatsAppInboundQueue = db.prepare(`
 `);
 
 const stmtSelectDueWhatsAppInboundQueue = db.prepare(`
-  SELECT id, dedupe_key, payload_json, attempt_count
+  SELECT id, dedupe_key, payload_json, attempt_count, created_at_ms
   FROM whatsapp_inbound_queue
   WHERE next_attempt_at_ms <= ?
   ORDER BY id ASC
@@ -5314,6 +5316,51 @@ function computeWhatsAppQueueRetryDelayMs(attemptCount: number): number {
   return Math.min(maxDelay, delay);
 }
 
+class WhatsAppInboundDeliveryError extends Error {
+  retryable: boolean;
+  statusCode: number | null;
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean;
+      statusCode?: number | null;
+      cause?: unknown;
+    },
+  ) {
+    super(message, "cause" in options ? { cause: options.cause } : undefined);
+    this.name = "WhatsAppInboundDeliveryError";
+    this.retryable = options.retryable;
+    this.statusCode =
+      typeof options.statusCode === "number" && Number.isFinite(options.statusCode)
+        ? Math.trunc(options.statusCode)
+        : null;
+  }
+}
+
+function isRetryableWhatsAppInboundStatus(statusCode: number): boolean {
+  return statusCode === 408 || statusCode === 425 || statusCode === 429 || statusCode >= 500;
+}
+
+function classifyWhatsAppInboundDeliveryError(error: unknown): {
+  retryable: boolean;
+  statusCode: number | null;
+  errorMessage: string;
+} {
+  if (error instanceof WhatsAppInboundDeliveryError) {
+    return {
+      retryable: error.retryable,
+      statusCode: error.statusCode,
+      errorMessage: errorString(error),
+    };
+  }
+  return {
+    retryable: true,
+    statusCode: null,
+    errorMessage: errorString(error),
+  };
+}
+
 function snapshotWhatsAppInboundMessage(message: WebInboundMessage): WebInboundMessage {
   return {
     id: readNonEmptyString(message.id) ?? undefined,
@@ -7601,16 +7648,41 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         messageId: message.id ?? null,
       });
     } catch (error) {
+      const failure = classifyWhatsAppInboundDeliveryError(error);
       const attemptCount = Math.max(
         1,
         Number.isFinite(row.attempt_count) ? Math.trunc(row.attempt_count) + 1 : 1,
       );
+      const createdAtMs =
+        Number.isFinite(row.created_at_ms) && row.created_at_ms > 0
+          ? Math.trunc(row.created_at_ms)
+          : now;
+      const ageMs = Math.max(0, now - createdAtMs);
+      const maxAgeMs = Math.max(1_000, Math.trunc(whatsappQueueMaxAgeMs));
+      if (!failure.retryable || ageMs >= maxAgeMs) {
+        stmtDeleteWhatsAppInboundQueueById.run(row.id);
+        metrics.recordInboundEvent("whatsapp", "dropped");
+        log({
+          type: "whatsapp_inbound_bg_retry_exhausted",
+          queueId: row.id,
+          dedupeKey: row.dedupe_key,
+          messageId: message.id ?? null,
+          attemptCount,
+          ageMs,
+          maxAgeMs,
+          retryable: failure.retryable,
+          statusCode: failure.statusCode,
+          error: failure.errorMessage,
+        });
+        continue;
+      }
+
       const retryDelayMs = computeWhatsAppQueueRetryDelayMs(attemptCount);
       const nextAttemptAtMs = Date.now() + retryDelayMs;
       stmtDeferWhatsAppInboundQueueById.run(
         nextAttemptAtMs,
         attemptCount,
-        String(error).slice(0, 2_000),
+        failure.errorMessage.slice(0, 2_000),
         Date.now(),
         row.id,
       );
@@ -7622,7 +7694,7 @@ async function processWhatsAppInboundQueuePass(): Promise<void> {
         attemptCount,
         retryDelayMs,
         nextAttemptAtMs,
-        error: String(error),
+        error: failure.errorMessage,
       });
     }
   }
@@ -7848,7 +7920,12 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
       chatJid,
       traceId,
     });
-    throw new Error(`whatsapp inbound target missing for tenant ${binding.tenantId}`);
+    throw new WhatsAppInboundDeliveryError(
+      `whatsapp inbound target missing for tenant ${binding.tenantId}`,
+      {
+        retryable: false,
+      },
+    );
   }
 
   const inboundMedia = await extractWhatsAppInboundMedia({ message });
@@ -7945,13 +8022,22 @@ async function forwardWhatsAppInboundMessage(message: WebInboundMessage) {
   } catch (error) {
     metrics.observeInboundForwardDuration("whatsapp", Date.now() - forwardStartedAtMs);
     metrics.recordInboundEvent("whatsapp", "error");
-    throw error;
+    throw new WhatsAppInboundDeliveryError(errorString(error), {
+      retryable: true,
+      cause: error,
+    });
   }
   if (!response.ok) {
     metrics.observeInboundForwardDuration("whatsapp", Date.now() - forwardStartedAtMs);
     metrics.recordInboundEvent("whatsapp", "error");
     const bodyText = await response.text();
-    throw new Error(`openclaw inbound failed (${response.status}): ${bodyText || "no body"}`);
+    throw new WhatsAppInboundDeliveryError(
+      `openclaw inbound failed (${response.status}): ${bodyText || "no body"}`,
+      {
+        retryable: isRetryableWhatsAppInboundStatus(response.status),
+        statusCode: response.status,
+      },
+    );
   }
   metrics.observeInboundForwardDuration("whatsapp", Date.now() - forwardStartedAtMs);
   metrics.recordInboundEvent("whatsapp", "forwarded");

--- a/mux-server/src/whatsapp-inbound-queue.ts
+++ b/mux-server/src/whatsapp-inbound-queue.ts
@@ -64,6 +64,12 @@ export function classifyWhatsAppInboundDeliveryError(
   };
 }
 
+function readPositiveInt(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : null;
+}
+
 export function resolveWhatsAppInboundQueueRetryState(input: {
   row: WhatsAppInboundQueueRetryRow;
   now: number;
@@ -77,26 +83,11 @@ export function resolveWhatsAppInboundQueueRetryState(input: {
   exhausted: boolean;
 } {
   const { row, now, maxAgeMs, failure } = input;
-  const attemptCount = Math.max(
-    1,
-    Number.isFinite(row.attempt_count) ? Math.trunc(row.attempt_count) + 1 : 1,
-  );
-  const createdAtMs =
-    Number.isFinite(row.created_at_ms) && row.created_at_ms > 0
-      ? Math.trunc(row.created_at_ms)
-      : now;
-  let deliveryWindowStartedAtMs =
-    Number.isFinite(row.delivery_window_started_at_ms) && row.delivery_window_started_at_ms > 0
-      ? Math.trunc(row.delivery_window_started_at_ms)
-      : createdAtMs;
-  let lastTargetUpdateAtMs =
-    Number.isFinite(row.last_target_update_at_ms) && row.last_target_update_at_ms > 0
-      ? Math.trunc(row.last_target_update_at_ms)
-      : 0;
-  const targetUpdatedAtMs =
-    Number.isFinite(failure.targetUpdatedAtMs) && (failure.targetUpdatedAtMs ?? 0) > 0
-      ? Math.trunc(failure.targetUpdatedAtMs ?? 0)
-      : 0;
+  const attemptCount = (readPositiveInt(row.attempt_count) ?? 0) + 1;
+  const createdAtMs = readPositiveInt(row.created_at_ms) ?? now;
+  let deliveryWindowStartedAtMs = readPositiveInt(row.delivery_window_started_at_ms) ?? createdAtMs;
+  let lastTargetUpdateAtMs = readPositiveInt(row.last_target_update_at_ms) ?? 0;
+  const targetUpdatedAtMs = readPositiveInt(failure.targetUpdatedAtMs) ?? 0;
   if (targetUpdatedAtMs > lastTargetUpdateAtMs) {
     deliveryWindowStartedAtMs = now;
     lastTargetUpdateAtMs = targetUpdatedAtMs;

--- a/mux-server/src/whatsapp-inbound-queue.ts
+++ b/mux-server/src/whatsapp-inbound-queue.ts
@@ -1,0 +1,112 @@
+export class WhatsAppInboundDeliveryError extends Error {
+  retryable: boolean;
+  statusCode: number | null;
+  targetUpdatedAtMs: number | null;
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean;
+      statusCode?: number | null;
+      targetUpdatedAtMs?: number | null;
+      cause?: unknown;
+    },
+  ) {
+    super(message, "cause" in options ? { cause: options.cause } : undefined);
+    this.name = "WhatsAppInboundDeliveryError";
+    this.retryable = options.retryable;
+    this.statusCode =
+      typeof options.statusCode === "number" && Number.isFinite(options.statusCode)
+        ? Math.trunc(options.statusCode)
+        : null;
+    this.targetUpdatedAtMs =
+      typeof options.targetUpdatedAtMs === "number" && Number.isFinite(options.targetUpdatedAtMs)
+        ? Math.trunc(options.targetUpdatedAtMs)
+        : null;
+  }
+}
+
+export type WhatsAppInboundDeliveryFailure = {
+  retryable: boolean;
+  statusCode: number | null;
+  targetUpdatedAtMs: number | null;
+  errorMessage: string;
+};
+
+type WhatsAppInboundQueueRetryRow = {
+  attempt_count: number;
+  created_at_ms: number;
+  delivery_window_started_at_ms: number;
+  last_target_update_at_ms: number;
+};
+
+export function isRetryableWhatsAppInboundStatus(statusCode: number): boolean {
+  return statusCode === 408 || statusCode === 425 || statusCode === 429 || statusCode >= 500;
+}
+
+export function classifyWhatsAppInboundDeliveryError(
+  error: unknown,
+  formatError: (error: unknown) => string,
+): WhatsAppInboundDeliveryFailure {
+  if (error instanceof WhatsAppInboundDeliveryError) {
+    return {
+      retryable: error.retryable,
+      statusCode: error.statusCode,
+      targetUpdatedAtMs: error.targetUpdatedAtMs,
+      errorMessage: formatError(error),
+    };
+  }
+  return {
+    retryable: true,
+    statusCode: null,
+    targetUpdatedAtMs: null,
+    errorMessage: formatError(error),
+  };
+}
+
+export function resolveWhatsAppInboundQueueRetryState(input: {
+  row: WhatsAppInboundQueueRetryRow;
+  now: number;
+  maxAgeMs: number;
+  failure: WhatsAppInboundDeliveryFailure;
+}): {
+  attemptCount: number;
+  deliveryWindowStartedAtMs: number;
+  lastTargetUpdateAtMs: number;
+  ageMs: number;
+  exhausted: boolean;
+} {
+  const { row, now, maxAgeMs, failure } = input;
+  const attemptCount = Math.max(
+    1,
+    Number.isFinite(row.attempt_count) ? Math.trunc(row.attempt_count) + 1 : 1,
+  );
+  const createdAtMs =
+    Number.isFinite(row.created_at_ms) && row.created_at_ms > 0
+      ? Math.trunc(row.created_at_ms)
+      : now;
+  let deliveryWindowStartedAtMs =
+    Number.isFinite(row.delivery_window_started_at_ms) && row.delivery_window_started_at_ms > 0
+      ? Math.trunc(row.delivery_window_started_at_ms)
+      : createdAtMs;
+  let lastTargetUpdateAtMs =
+    Number.isFinite(row.last_target_update_at_ms) && row.last_target_update_at_ms > 0
+      ? Math.trunc(row.last_target_update_at_ms)
+      : 0;
+  const targetUpdatedAtMs =
+    Number.isFinite(failure.targetUpdatedAtMs) && (failure.targetUpdatedAtMs ?? 0) > 0
+      ? Math.trunc(failure.targetUpdatedAtMs ?? 0)
+      : 0;
+  if (targetUpdatedAtMs > lastTargetUpdateAtMs) {
+    deliveryWindowStartedAtMs = now;
+    lastTargetUpdateAtMs = targetUpdatedAtMs;
+  }
+  const ageMs = Math.max(0, now - deliveryWindowStartedAtMs);
+  return {
+    attemptCount,
+    deliveryWindowStartedAtMs,
+    lastTargetUpdateAtMs,
+    ageMs,
+    exhausted: !failure.retryable || ageMs >= Math.max(1_000, Math.trunc(maxAgeMs)),
+  };
+}

--- a/mux-server/test/server.inbound-forwarding.test.ts
+++ b/mux-server/test/server.inbound-forwarding.test.ts
@@ -1093,6 +1093,127 @@ describe("mux server", () => {
     h.rmSync(tempDir, { recursive: true, force: true });
   }, 15_000);
 
+  test("refreshes WhatsApp queue retention when the tenant re-registers at the same inbound url", async () => {
+    const tempDir = h.mkdtempSync(h.resolve(h.tmpdir(), "mux-server-wa-reregister-"));
+    const authDir = h.resolve(tempDir, "wa-auth");
+    const runtimePath = h.resolve(tempDir, "mock-web-runtime.mjs");
+    const dbPath = h.resolve(tempDir, "mux-server.sqlite");
+    const logPath = h.resolve(tempDir, "mux-server.log");
+    mkdirSync(authDir, { recursive: true });
+    h.writeFileSync(h.resolve(authDir, "creds.json"), "{}", "utf8");
+    writeWhatsAppRuntimeMock({
+      runtimePath,
+      emitDelayMs: 300,
+      message: {
+        id: "wa-reregister-1",
+        from: "15550003333@s.whatsapp.net",
+        to: "15559990000@s.whatsapp.net",
+        accountId: "default",
+        body: "deliver after reregister",
+        timestamp: 1_700_000_000_000,
+        chatType: "direct",
+        chatId: "15550003333@s.whatsapp.net",
+        senderJid: "15550003333@s.whatsapp.net",
+        senderE164: "+15550003333",
+      },
+    });
+
+    let acceptInbound = false;
+    let successfulDeliveries = 0;
+    const inbound = await h.startHttpServer(async (req, res) => {
+      if (req.method !== "POST" || req.url !== "/v1/mux/inbound") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      await h.readJsonBody(req);
+      if (!acceptInbound) {
+        res.writeHead(503, { "content-type": "application/json; charset=utf-8" });
+        res.end(JSON.stringify({ ok: false, error: "offline" }));
+        return;
+      }
+      successfulDeliveries += 1;
+      res.writeHead(202, { "content-type": "application/json; charset=utf-8" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    const server = await h.startServer({
+      tempDir,
+      cleanupTempDir: false,
+      dbPath,
+      tenantsJson: JSON.stringify([
+        {
+          id: "tenant-a",
+          name: "Tenant A",
+          apiKey: "tenant-a-key",
+          inboundUrl: `${inbound.url}/v1/mux/inbound`,
+          inboundTimeoutMs: 500,
+        },
+      ]),
+      pairingCodesJson: JSON.stringify([
+        {
+          code: "PAIR-WA-REREGISTER",
+          channel: "whatsapp",
+          routeKey: "whatsapp:default:chat:15550003333@s.whatsapp.net",
+          scope: "chat",
+        },
+      ]),
+      extraEnv: {
+        MUX_WEB_RUNTIME_MODULE_PATH: runtimePath,
+        MUX_WHATSAPP_AUTH_DIR: authDir,
+        MUX_WHATSAPP_QUEUE_POLL_MS: "25",
+        MUX_WHATSAPP_QUEUE_RETRY_INITIAL_MS: "50",
+        MUX_WHATSAPP_QUEUE_RETRY_MAX_MS: "50",
+        MUX_WHATSAPP_QUEUE_MAX_AGE_MS: "1000",
+      },
+    });
+
+    const claim = await h.claimPairing({
+      port: server.port,
+      apiKey: "tenant-a-key",
+      code: "PAIR-WA-REREGISTER",
+      sessionKey: "agent:main:whatsapp:direct:15550003333",
+    });
+    expect(claim.status).toBe(200);
+
+    await h.waitForCondition(
+      () => h.readMuxServerLog(logPath).includes('"type":"whatsapp_inbound_retry_deferred"'),
+      4_000,
+      "timed out waiting for initial WhatsApp retry deferral",
+    );
+
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 500));
+    const refresh = await h.createAdminPairingToken({
+      port: server.port,
+      adminToken: h.DEFAULT_ADMIN_TOKEN,
+      openclawId: "tenant-a",
+      inboundUrl: `${inbound.url}/v1/mux/inbound`,
+      inboundTimeoutMs: 500,
+      ttlSec: 60,
+    });
+    expect(refresh.status).toBe(200);
+
+    // Stay unavailable long enough that the original delivery window would have
+    // expired, then allow delivery after the registration epoch refresh.
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 700));
+    acceptInbound = true;
+
+    await h.waitForCondition(
+      () => successfulDeliveries >= 1,
+      4_000,
+      "timed out waiting for WhatsApp delivery after same-url re-registration",
+    );
+
+    expect(readWhatsAppQueueDepth(dbPath)).toBe(0);
+    const logText = h.readMuxServerLog(logPath);
+    expect(logText).toContain('"messageId":"wa-reregister-1"');
+    expect(logText).not.toContain('"type":"whatsapp_inbound_bg_retry_exhausted"');
+
+    await h.stopServer(server);
+    h.removeRunningServer(server);
+    h.rmSync(tempDir, { recursive: true, force: true });
+  }, 15_000);
+
   test("drops non-retryable WhatsApp inbound delivery failures immediately", async () => {
     const tempDir = h.mkdtempSync(h.resolve(h.tmpdir(), "mux-server-wa-nonretryable-"));
     const authDir = h.resolve(tempDir, "wa-auth");

--- a/mux-server/test/server.inbound-forwarding.test.ts
+++ b/mux-server/test/server.inbound-forwarding.test.ts
@@ -1,5 +1,60 @@
+import { mkdirSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, test } from "vitest";
 import * as h from "./server.test.helpers";
+
+function readWhatsAppQueueDepth(dbPath: string): number {
+  const db = new DatabaseSync(dbPath, { open: true, readOnly: true });
+  try {
+    const row = db.prepare("SELECT COUNT(*) AS count FROM whatsapp_inbound_queue").get() as {
+      count?: unknown;
+    };
+    return typeof row.count === "number" && Number.isFinite(row.count) ? Math.trunc(row.count) : 0;
+  } finally {
+    db.close();
+  }
+}
+
+function writeWhatsAppRuntimeMock(params: {
+  runtimePath: string;
+  message: Record<string, unknown>;
+  emitDelayMs?: number;
+}) {
+  h.writeFileSync(
+    params.runtimePath,
+    `const emitDelayMs = Number(process.env.MUX_TEST_WHATSAPP_EMIT_DELAY_MS || ${Math.max(
+      0,
+      Math.trunc(params.emitDelayMs ?? 300),
+    )});
+const message = ${JSON.stringify(params.message)};
+
+export async function monitorWebInbox(options) {
+  let closeResolve;
+  const onClose = new Promise((resolve) => {
+    closeResolve = resolve;
+  });
+  setTimeout(() => {
+    void options.onMessage(message);
+  }, emitDelayMs);
+  return {
+    onClose,
+    async close() {
+      closeResolve?.({ status: 0, isLoggedOut: false });
+    },
+  };
+}
+
+export async function sendMessageWhatsApp() {
+  return { messageId: "mock-message-id", toJid: "15550001111@s.whatsapp.net" };
+}
+
+export async function sendTypingWhatsApp() {}
+
+export function setActiveWebListener() {}
+`,
+    "utf8",
+  );
+}
 
 describe("mux server", () => {
   test("forwards inbound Telegram updates to tenant inbound endpoint", async () => {
@@ -950,5 +1005,183 @@ describe("mux server", () => {
     const msgTwoCount = inboundAttempts.filter((payload) => payload.body === "msg-two").length;
     expect(msgOneCount).toBe(1);
     expect(msgTwoCount).toBe(2);
+  }, 15_000);
+
+  test("expires WhatsApp queued inbound retries after the retention window", async () => {
+    const tempDir = h.mkdtempSync(h.resolve(h.tmpdir(), "mux-server-wa-retry-expire-"));
+    const authDir = h.resolve(tempDir, "wa-auth");
+    const runtimePath = h.resolve(tempDir, "mock-web-runtime.mjs");
+    const dbPath = h.resolve(tempDir, "mux-server.sqlite");
+    const logPath = h.resolve(tempDir, "mux-server.log");
+    mkdirSync(authDir, { recursive: true });
+    h.writeFileSync(h.resolve(authDir, "creds.json"), "{}", "utf8");
+    writeWhatsAppRuntimeMock({
+      runtimePath,
+      emitDelayMs: 300,
+      message: {
+        id: "wa-expire-1",
+        from: "15550001111@s.whatsapp.net",
+        to: "15559990000@s.whatsapp.net",
+        accountId: "default",
+        body: "queued transport failure",
+        timestamp: 1_700_000_000_000,
+        chatType: "direct",
+        chatId: "15550001111@s.whatsapp.net",
+        senderJid: "15550001111@s.whatsapp.net",
+        senderE164: "+15550001111",
+      },
+    });
+
+    const unavailablePort = await h.getFreePort();
+    const server = await h.startServer({
+      tempDir,
+      cleanupTempDir: false,
+      dbPath,
+      tenantsJson: JSON.stringify([
+        {
+          id: "tenant-a",
+          name: "Tenant A",
+          apiKey: "tenant-a-key",
+          inboundUrl: `http://127.0.0.1:${unavailablePort}/v1/mux/inbound`,
+          inboundTimeoutMs: 200,
+        },
+      ]),
+      pairingCodesJson: JSON.stringify([
+        {
+          code: "PAIR-WA-RETRY-EXPIRE",
+          channel: "whatsapp",
+          routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+          scope: "chat",
+        },
+      ]),
+      extraEnv: {
+        MUX_WEB_RUNTIME_MODULE_PATH: runtimePath,
+        MUX_WHATSAPP_AUTH_DIR: authDir,
+        MUX_WHATSAPP_QUEUE_POLL_MS: "25",
+        MUX_WHATSAPP_QUEUE_RETRY_INITIAL_MS: "50",
+        MUX_WHATSAPP_QUEUE_RETRY_MAX_MS: "50",
+        MUX_WHATSAPP_QUEUE_MAX_AGE_MS: "220",
+      },
+    });
+
+    const claim = await h.claimPairing({
+      port: server.port,
+      apiKey: "tenant-a-key",
+      code: "PAIR-WA-RETRY-EXPIRE",
+      sessionKey: "agent:main:whatsapp:direct:15550001111",
+    });
+    expect(claim.status).toBe(200);
+
+    await h.waitForCondition(
+      () => h.readMuxServerLog(logPath).includes('"type":"whatsapp_inbound_retry_deferred"'),
+      4_000,
+      "timed out waiting for WhatsApp retry deferral",
+    );
+    await h.waitForCondition(
+      () => h.readMuxServerLog(logPath).includes('"type":"whatsapp_inbound_bg_retry_exhausted"'),
+      4_000,
+      "timed out waiting for WhatsApp retry exhaustion",
+    );
+
+    expect(readWhatsAppQueueDepth(dbPath)).toBe(0);
+    const logText = h.readMuxServerLog(logPath);
+    expect(logText).toContain('"messageId":"wa-expire-1"');
+    expect(logText).toContain('"retryable":true');
+
+    await h.stopServer(server);
+    h.removeRunningServer(server);
+    h.rmSync(tempDir, { recursive: true, force: true });
+  }, 15_000);
+
+  test("drops non-retryable WhatsApp inbound delivery failures immediately", async () => {
+    const tempDir = h.mkdtempSync(h.resolve(h.tmpdir(), "mux-server-wa-nonretryable-"));
+    const authDir = h.resolve(tempDir, "wa-auth");
+    const runtimePath = h.resolve(tempDir, "mock-web-runtime.mjs");
+    const dbPath = h.resolve(tempDir, "mux-server.sqlite");
+    const logPath = h.resolve(tempDir, "mux-server.log");
+    mkdirSync(authDir, { recursive: true });
+    h.writeFileSync(h.resolve(authDir, "creds.json"), "{}", "utf8");
+    writeWhatsAppRuntimeMock({
+      runtimePath,
+      emitDelayMs: 300,
+      message: {
+        id: "wa-nonretryable-1",
+        from: "15550002222@s.whatsapp.net",
+        to: "15559990000@s.whatsapp.net",
+        accountId: "default",
+        body: "bad request",
+        timestamp: 1_700_000_000_000,
+        chatType: "direct",
+        chatId: "15550002222@s.whatsapp.net",
+        senderJid: "15550002222@s.whatsapp.net",
+        senderE164: "+15550002222",
+      },
+    });
+
+    const inbound = await h.startHttpServer(async (req, res) => {
+      if (req.method !== "POST" || req.url !== "/v1/mux/inbound") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      await h.readJsonBody(req);
+      res.writeHead(400, { "content-type": "application/json; charset=utf-8" });
+      res.end(JSON.stringify({ ok: false, error: "bad request" }));
+    });
+
+    const server = await h.startServer({
+      tempDir,
+      cleanupTempDir: false,
+      dbPath,
+      tenantsJson: JSON.stringify([
+        {
+          id: "tenant-a",
+          name: "Tenant A",
+          apiKey: "tenant-a-key",
+          inboundUrl: `${inbound.url}/v1/mux/inbound`,
+          inboundTimeoutMs: 1_000,
+        },
+      ]),
+      pairingCodesJson: JSON.stringify([
+        {
+          code: "PAIR-WA-NONRETRYABLE",
+          channel: "whatsapp",
+          routeKey: "whatsapp:default:chat:15550002222@s.whatsapp.net",
+          scope: "chat",
+        },
+      ]),
+      extraEnv: {
+        MUX_WEB_RUNTIME_MODULE_PATH: runtimePath,
+        MUX_WHATSAPP_AUTH_DIR: authDir,
+        MUX_WHATSAPP_QUEUE_POLL_MS: "25",
+        MUX_WHATSAPP_QUEUE_RETRY_INITIAL_MS: "500",
+        MUX_WHATSAPP_QUEUE_RETRY_MAX_MS: "500",
+        MUX_WHATSAPP_QUEUE_MAX_AGE_MS: "5000",
+      },
+    });
+
+    const claim = await h.claimPairing({
+      port: server.port,
+      apiKey: "tenant-a-key",
+      code: "PAIR-WA-NONRETRYABLE",
+      sessionKey: "agent:main:whatsapp:direct:15550002222",
+    });
+    expect(claim.status).toBe(200);
+
+    await h.waitForCondition(
+      () => h.readMuxServerLog(logPath).includes('"type":"whatsapp_inbound_bg_retry_exhausted"'),
+      4_000,
+      "timed out waiting for non-retryable WhatsApp exhaustion",
+    );
+
+    expect(readWhatsAppQueueDepth(dbPath)).toBe(0);
+    const logText = h.readMuxServerLog(logPath);
+    expect(logText).toContain('"messageId":"wa-nonretryable-1"');
+    expect(logText).toContain('"retryable":false');
+    expect(logText).not.toContain('"type":"whatsapp_inbound_retry_deferred"');
+
+    await h.stopServer(server);
+    h.removeRunningServer(server);
+    h.rmSync(tempDir, { recursive: true, force: true });
   }, 15_000);
 });


### PR DESCRIPTION
## Summary
- bound WhatsApp inbound queue retries with an explicit retention window and terminal classification for non-retryable delivery failures
- refresh queued inbound delivery retention when the tenant re-registers, even if the inbound URL is unchanged
- treat missing inbound target as deferred until the tenant comes back online instead of pinning retries to stale routing state

## Testing
- pnpm --dir mux-server typecheck
- pnpm --dir mux-server exec vitest run --config vitest.config.ts test/server.inbound-forwarding.test.ts -t "expires WhatsApp queued inbound retries after the retention window|refreshes WhatsApp queue retention when the tenant re-registers at the same inbound url|drops non-retryable WhatsApp inbound delivery failures immediately" --reporter=verbose
- pnpm --dir openclaw exec vitest run --config phala-deploy/integration-test/vitest.config.ts phala-deploy/integration-test/whatsapp.mux-roundtrip.e2e.test.ts
- pnpm --dir openclaw exec vitest run --config phala-deploy/integration-test/vitest.config.ts
