### PR TITLE
feat: slim CVM image — remove bloat, Docker opt-in

### DIFF
--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -58,32 +58,24 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-# --- Stage 3: Production base (openclaw from tarball) ---
+# --- Stage 2: Production image (openclaw from tarball + SSH) ---
 FROM base-prereqs AS base
 
 COPY phala-deploy/openclaw.tgz /tmp/openclaw.tgz
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential && \
+    apt-get install -y --no-install-recommends build-essential openssh-server && \
     npm install -g /tmp/openclaw.tgz && \
     rm -f /tmp/openclaw.tgz && \
     rm -f /root/.openclaw/openclaw.json /root/.openclaw/openclaw.json.bak && \
     apt-get purge -y --auto-remove build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.npm /tmp/* /usr/include
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
 
-# --- Stage 4: Dev image (openclaw via bind mount) ---
+# --- Stage 3: Dev image (openclaw via bind mount) ---
 FROM base-prereqs AS dev
 
 RUN printf '#!/bin/sh\nexec node /app/openclaw.mjs "$@"\n' > /usr/local/bin/openclaw && \
     chmod +x /usr/local/bin/openclaw
-
-# --- Stage 5: Full image (standalone with SSH) ---
-FROM base AS full
-
-# SSH daemon
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends openssh-server && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/run/sshd && \
-    sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
 

--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -1,17 +1,4 @@
-# --- Stage 1: Build gogcli (Google API CLI with env-var credential injection) ---
-FROM golang:1.25-bookworm AS gogcli-builder
-ARG GOGCLI_REPO=https://github.com/Leechael/gogcli.git
-ARG GOGCLI_BRANCH=feat/env-token-injection
-RUN git clone --depth 1 --branch "$GOGCLI_BRANCH" "$GOGCLI_REPO" /src/gogcli
-WORKDIR /src/gogcli
-RUN CGO_ENABLED=0 go build \
-      -ldflags "-s -w \
-        -X github.com/steipete/gogcli/internal/cmd.version=$(git describe --tags --always --dirty 2>/dev/null || echo dev) \
-        -X github.com/steipete/gogcli/internal/cmd.commit=$(git rev-parse --short=12 HEAD) \
-        -X github.com/steipete/gogcli/internal/cmd.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      -o /out/gog-bin ./cmd/gog
-
-# --- Stage 2: Base prerequisites (system deps, no openclaw) ---
+# --- Stage 1: Base prerequisites (system deps, no openclaw) ---
 FROM ubuntu:24.04 AS base-prereqs
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -61,11 +48,6 @@ RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /root/.bash
 RUN npm install -g mcporter && \
     rm -rf /root/.npm /tmp/*
 
-# gogcli: static binary + credential-sourcing wrapper
-COPY --from=gogcli-builder /out/gog-bin /usr/local/bin/gog-bin
-COPY phala-deploy/gogcli/gog-wrapper.sh /usr/local/bin/gog
-RUN chmod +x /usr/local/bin/gog /usr/local/bin/gog-bin
-
 COPY phala-deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -84,8 +66,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential && \
     npm install -g /tmp/openclaw.tgz && \
     rm -f /tmp/openclaw.tgz && \
-    openclaw plugins install @tencent-connect/openclaw-qqbot@latest && \
-    openclaw plugins install @dingtalk-real-ai/dingtalk-connector@latest && \
     rm -f /root/.openclaw/openclaw.json /root/.openclaw/openclaw.json.bak && \
     apt-get purge -y --auto-remove build-essential && \
     apt-get clean && \
@@ -97,7 +77,7 @@ FROM base-prereqs AS dev
 RUN printf '#!/bin/sh\nexec node /app/openclaw.mjs "$@"\n' > /usr/local/bin/openclaw && \
     chmod +x /usr/local/bin/openclaw
 
-# --- Stage 5: Full image (standalone with SSH + S3 support) ---
+# --- Stage 5: Full image (standalone with SSH) ---
 FROM base AS full
 
 # SSH daemon
@@ -107,15 +87,3 @@ RUN apt-get update && \
 RUN mkdir -p /var/run/sshd && \
     sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
 
-# rclone for encrypted S3 mount (single static binary, ~50MB)
-ARG RCLONE_VERSION=1.73.0
-RUN curl -fsSL "https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip" \
-      -o /tmp/rclone.zip && \
-    unzip -j /tmp/rclone.zip '*/rclone' -d /usr/local/bin && \
-    chmod +x /usr/local/bin/rclone && \
-    rm /tmp/rclone.zip
-
-# fuse3 for rclone mount
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends fuse3 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -58,20 +58,18 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-# --- Stage 2: Production image (openclaw from tarball + SSH) ---
+# --- Stage 2: Production image (openclaw from tarball) ---
 FROM base-prereqs AS base
 
 COPY phala-deploy/openclaw.tgz /tmp/openclaw.tgz
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential openssh-server && \
+    apt-get install -y --no-install-recommends build-essential && \
     npm install -g /tmp/openclaw.tgz && \
     rm -f /tmp/openclaw.tgz && \
     rm -f /root/.openclaw/openclaw.json /root/.openclaw/openclaw.json.bak && \
     apt-get purge -y --auto-remove build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.npm /tmp/* /usr/include
-RUN mkdir -p /var/run/sshd && \
-    sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
 
 # --- Stage 3: Dev image (openclaw via bind mount) ---
 FROM base-prereqs AS dev

--- a/phala-deploy/build-openclaw.sh
+++ b/phala-deploy/build-openclaw.sh
@@ -4,12 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-FULL_IMAGE_REPO="${PHALA_IMAGE_REPO:-h4x3rotab/openclaw-cvm}"
-BASE_IMAGE_REPO="${PHALA_BASE_IMAGE_REPO:-${FULL_IMAGE_REPO}-base}"
+IMAGE_REPO="${PHALA_IMAGE_REPO:-h4x3rotab/openclaw-cvm}"
 IMAGE_TAG="${PHALA_IMAGE_TAG:-$(bash "$SCRIPT_DIR/release-meta.sh" full-version "$ROOT_DIR/package.json")}"
-
-FULL_IMAGE_REF="${FULL_IMAGE_REPO}:${IMAGE_TAG}"
-BASE_IMAGE_REF="${BASE_IMAGE_REPO}:${IMAGE_TAG}"
+IMAGE_REF="${IMAGE_REPO}:${IMAGE_TAG}"
 
 pnpm --dir "$ROOT_DIR" ui:install
 PACK_OUT="$(npm --prefix "$ROOT_DIR" pack --pack-destination "$SCRIPT_DIR")"
@@ -17,10 +14,8 @@ TGZ_NAME="$(printf '%s\n' "$PACK_OUT" | tail -n 1 | tr -d '[:space:]')"
 rm -f "$SCRIPT_DIR/openclaw.tgz"
 mv -f "$SCRIPT_DIR/$TGZ_NAME" "$SCRIPT_DIR/openclaw.tgz"
 
-docker build --target full -f "$SCRIPT_DIR/Dockerfile" -t "$FULL_IMAGE_REF" "$ROOT_DIR"
-docker build --target base -f "$SCRIPT_DIR/Dockerfile" -t "$BASE_IMAGE_REF" "$ROOT_DIR"
+docker build --target base -f "$SCRIPT_DIR/Dockerfile" -t "$IMAGE_REF" "$ROOT_DIR"
 
 if [[ "${PHALA_NO_PUSH:-0}" != "1" ]]; then
-  docker push "$FULL_IMAGE_REF"
-  docker push "$BASE_IMAGE_REF"
+  docker push "$IMAGE_REF"
 fi

--- a/phala-deploy/entrypoint.sh
+++ b/phala-deploy/entrypoint.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 set -e
 
-# Persistent storage root (S3 mount or Docker volume)
+# Persistent storage root (Docker volume or k8s PVC)
 DATA_DIR="/data"
-SQLITE_LOCAL_DIR="/data-local/sqlite"
 
-# --- Derive keys from MASTER_KEY via HKDF-SHA256 ---
-# One master secret derives: rclone crypt password, crypt salt, gateway auth token.
-# S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) are provider-issued and stay separate.
+# --- Derive gateway auth token from MASTER_KEY via HKDF-SHA256 ---
 if [ -n "$MASTER_KEY" ]; then
   echo "Deriving keys from MASTER_KEY..."
   derive_key() {
@@ -20,118 +17,10 @@ if [ -n "$MASTER_KEY" ]; then
 
   GATEWAY_AUTH_TOKEN=$(derive_key gateway-auth-token | tr -d '/+=' | head -c 32)
   export GATEWAY_AUTH_TOKEN
-
-  # Derive rclone keys only if rclone is installed
-  if command -v rclone >/dev/null 2>&1; then
-    RCLONE_CRYPT_PASSWORD=$(rclone obscure "$(derive_key rclone-crypt-password)")
-    RCLONE_CRYPT_PASSWORD2=$(rclone obscure "$(derive_key rclone-crypt-salt)")
-    export RCLONE_CRYPT_PASSWORD RCLONE_CRYPT_PASSWORD2
-    echo "Keys derived (gateway token, crypt password, crypt salt)."
-  else
-    echo "Keys derived (gateway token)."
-  fi
+  echo "Keys derived."
 fi
 
-# --- Encrypted S3 storage via rclone crypt + mount ---
-if [ -n "$S3_BUCKET" ]; then
-  if ! command -v rclone >/dev/null 2>&1; then
-    echo "Error: S3_BUCKET is set but rclone is not installed. Use the full image for S3 support."
-    mkdir -p "$DATA_DIR"
-  else
-    echo "S3 storage configured (bucket: $S3_BUCKET), setting up rclone..."
-
-    S3_PREFIX="${S3_PREFIX:-openclaw-data}"
-    S3_REGION="${S3_REGION:-us-east-1}"
-
-    # Generate rclone config from env vars (write to temp location, not ~/.config)
-    mkdir -p /tmp/rclone
-    cat > /tmp/rclone/rclone.conf <<RCONF
-[s3]
-type = s3
-provider = ${S3_PROVIDER:-Other}
-env_auth = true
-endpoint = ${S3_ENDPOINT}
-region = ${S3_REGION}
-no_check_bucket = true
-
-[s3-crypt]
-type = crypt
-remote = s3:${S3_BUCKET}/${S3_PREFIX}
-password = ${RCLONE_CRYPT_PASSWORD}
-password2 = ${RCLONE_CRYPT_PASSWORD2:-}
-filename_encryption = standard
-directory_name_encryption = true
-RCONF
-    export RCLONE_CONFIG=/tmp/rclone/rclone.conf
-
-    # Try FUSE mount first; fall back to rclone sync if FUSE unavailable
-    mkdir -p "$DATA_DIR"
-    S3_MODE=""
-
-    if [ -e /dev/fuse ]; then
-      echo "Attempting FUSE mount..."
-      # Unmount Docker volume if present (FUSE can't overlay on existing mounts)
-      if mountpoint -q "$DATA_DIR" 2>/dev/null; then
-        echo "Unmounting existing volume at $DATA_DIR..."
-        umount "$DATA_DIR" 2>/dev/null || true
-      fi
-      rclone mount s3-crypt: "$DATA_DIR" \
-        --config "$RCLONE_CONFIG" \
-        --vfs-cache-mode writes \
-        --vfs-write-back 5s \
-        --dir-cache-time 30s \
-        --vfs-cache-max-size 500M \
-        --allow-other \
-        --daemon 2>&1 || true
-
-      # Wait for FUSE mount (up to 10s) — check for fuse.rclone specifically,
-      # not just mountpoint (Docker volume is already a mountpoint)
-      MOUNT_WAIT=0
-      while ! mount | grep -q "on $DATA_DIR type fuse.rclone"; do
-        sleep 0.5
-        MOUNT_WAIT=$((MOUNT_WAIT + 1))
-        if [ $MOUNT_WAIT -ge 20 ]; then
-          break
-        fi
-      done
-
-      if mount | grep -q "on $DATA_DIR type fuse.rclone"; then
-        S3_MODE="mount"
-        echo "rclone FUSE mount ready at $DATA_DIR"
-      else
-        echo "FUSE mount failed, falling back to sync mode."
-      fi
-    fi
-
-    # Fallback: sync mode (pull from S3, periodic push back)
-    if [ -z "$S3_MODE" ]; then
-      S3_MODE="sync"
-      echo "Using rclone sync mode (no FUSE)."
-      # Restore SQLite files to local storage (can't run on FUSE, use symlinks instead)
-      mkdir -p "$SQLITE_LOCAL_DIR"
-      echo "Restoring SQLite files from S3..."
-      rclone copy s3-crypt:sqlite/ "$SQLITE_LOCAL_DIR/" --config "$RCLONE_CONFIG" 2>/dev/null || true
-      # Pull remaining state
-      rclone copy s3-crypt: "$DATA_DIR/" --config "$RCLONE_CONFIG" --exclude "sqlite/**" 2>&1 || true
-      echo "Initial sync from S3 complete."
-    fi
-
-    # In sync mode, run periodic background jobs to push changes to S3.
-    # In mount mode, rclone VFS cache handles syncing automatically.
-    if [ "$S3_MODE" = "sync" ]; then
-      (
-        while true; do
-          sleep 60
-          rclone copy "$SQLITE_LOCAL_DIR/" s3-crypt:sqlite/ --config "$RCLONE_CONFIG" 2>/dev/null || true
-          rclone copy "$DATA_DIR/" s3-crypt: --config "$RCLONE_CONFIG" --exclude "sqlite/**" 2>/dev/null || true
-        done
-      ) &
-      echo "Background sync started (PID $!)"
-    fi
-  fi
-else
-  mkdir -p "$DATA_DIR"
-fi
+mkdir -p "$DATA_DIR"
 
 # --- Set up home directory symlinks ---
 # ~/.openclaw → /data/openclaw (state dir)
@@ -230,29 +119,6 @@ if [ -n "$MASTER_KEY" ]; then
   ' "$PAIRED_JSON"
 fi
 
-# --- SQLite symlink helper ---
-# Called after gateway creates agent dirs to redirect memory.db to local storage
-setup_sqlite_symlinks() {
-  if [ -z "$S3_BUCKET" ]; then return; fi
-  for agent_dir in /root/.openclaw/agents/*/; do
-    [ -d "$agent_dir" ] || continue
-    agent_id=$(basename "$agent_dir")
-    local_db="$SQLITE_LOCAL_DIR/${agent_id}-memory.db"
-    target_db="${agent_dir}memory.db"
-    # If real file exists on mount, move it to local
-    if [ -f "$target_db" ] && [ ! -L "$target_db" ]; then
-      cp "$target_db" "$local_db" 2>/dev/null || true
-      rm -f "$target_db"
-    fi
-    # Create symlink if not already there
-    if [ ! -L "$target_db" ]; then
-      # Ensure local db exists (may have been restored from S3)
-      touch "$local_db"
-      ln -sf "$local_db" "$target_db"
-    fi
-  done
-}
-
 # Start SSH daemon if installed (full image only)
 if [ -x /usr/sbin/sshd ]; then
   mkdir -p /var/run/sshd /root/.ssh
@@ -262,45 +128,32 @@ if [ -x /usr/sbin/sshd ]; then
   echo "SSH daemon started."
 fi
 
-# Clean up stale PID files from previous container restarts
-rm -f /var/run/docker.pid /var/run/containerd/containerd.pid
+# Start Docker daemon only when explicitly enabled (e.g. Phala CVM).
+# k3s pods don't need Docker — the agent runs directly on the host.
+if [ "${ENABLE_DOCKER:-}" = "1" ]; then
+  rm -f /var/run/docker.pid /var/run/containerd/containerd.pid
+  dockerd --host=unix:///var/run/docker.sock --storage-driver=vfs &
+  DOCKERD_PID=$!
 
-# Start Docker daemon in background (best-effort, not critical for gateway)
-# TODO: This blocking wait adds ~20s to startup. The gateway HTTP/WS server
-# doesn't need Docker — only tool execution does. Move the wait into a
-# background task and let the gateway start immediately.
-dockerd --host=unix:///var/run/docker.sock --storage-driver=vfs &
-DOCKERD_PID=$!
-
-echo "Waiting for Docker daemon..."
-DOCKER_WAIT=0
-while ! docker info >/dev/null 2>&1; do
-  sleep 1
-  DOCKER_WAIT=$((DOCKER_WAIT + 1))
-  if [ $DOCKER_WAIT -ge 30 ]; then
-    echo "Warning: Docker daemon not ready after 30s, continuing without it."
-    break
+  echo "Waiting for Docker daemon..."
+  DOCKER_WAIT=0
+  while ! docker info >/dev/null 2>&1; do
+    sleep 1
+    DOCKER_WAIT=$((DOCKER_WAIT + 1))
+    if [ $DOCKER_WAIT -ge 30 ]; then
+      echo "Warning: Docker daemon not ready after 30s, continuing without it."
+      break
+    fi
+    if ! kill -0 $DOCKERD_PID 2>/dev/null; then
+      echo "Warning: Docker daemon exited, continuing without it."
+      break
+    fi
+  done
+  if docker info >/dev/null 2>&1; then
+    echo "Docker daemon ready."
   fi
-  # Check if dockerd process died
-  if ! kill -0 $DOCKERD_PID 2>/dev/null; then
-    echo "Warning: Docker daemon exited, continuing without it."
-    break
-  fi
-done
-if docker info >/dev/null 2>&1; then
-  echo "Docker daemon ready."
-fi
-
-# Set up SQLite symlinks — only needed in sync mode (no VFS cache).
-# In FUSE mount mode, --vfs-cache-mode writes handles SQLite locally.
-if [ "$S3_MODE" = "sync" ]; then
-  setup_sqlite_symlinks
-  (
-    while true; do
-      sleep 30
-      setup_sqlite_symlinks
-    done
-  ) &
+else
+  echo "Docker daemon disabled (set ENABLE_DOCKER=1 to enable)."
 fi
 
 # Gateway supervision (keep container alive for SSH even if gateway fails).


### PR DESCRIPTION
## Summary

- Remove gogcli, rclone, and plugins from the CVM image to reduce size from ~4GB to 1.63GB
- Make Docker daemon opt-in via `ENABLE_DOCKER=1` env var (saves ~200MB RSS at runtime)
- Merge SSH into the base image stage, remove the separate full image stage

## What changed

- `phala-deploy/Dockerfile` — single-stage build, no gogcli/rclone/plugins, Docker opt-in
- `phala-deploy/entrypoint.sh` — only start Docker daemon when `ENABLE_DOCKER=1` is set
- `phala-deploy/build-openclaw.sh` — simplified build script (single image target)

## Test plan

- [x] Image builds successfully: `ghcr.io/clawdi-ai/openclaw:2026.3.25-k3s.1` (1.63GB)
- [x] Gateway starts and serves healthcheck 200
- [x] Docker disabled by default, enabled with `ENABLE_DOCKER=1`
- [x] Deployed and verified on prod2 k3s cluster