### PR TITLE
CVM: add python3-pip and python3-venv to base image

### DIFF
--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -7,9 +7,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg git bash tmux unzip lsof \
-      iptables lsb-release sudo && \
+      iptables lsb-release sudo \
+      python3-pip python3-venv && \
     update-alternatives --set iptables /usr/sbin/iptables-legacy && \
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
+    rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Docker static binaries + compose plugin (~80MB vs ~280MB for docker-ce)


### PR DESCRIPTION
## Summary

- Install `python3-pip` and `python3-venv` in the CVM base image so the agent can run Python code and install packages
- Remove Ubuntu 24.04's PEP 668 `EXTERNALLY-MANAGED` marker since this is a container environment where system-wide pip install is safe

## Context

Users reported the agent couldn't install Python packages (e.g. `pip install uvicorn`) because pip was not installed in the container, and even if it were, PEP 668 would block system-wide installs.

## Test plan

- [ ] Build the image and verify `python3 --version`, `pip3 --version`, and `pip3 install requests` all work
- [ ] Verify `python3 -m venv /tmp/testvenv && /tmp/testvenv/bin/pip install flask` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)