### PR TITLE
feat: slim k3s-ready image — remove bloat, workspace bootstrap

### DIFF
--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -75,4 +75,3 @@ FROM base-prereqs AS dev
 
 RUN printf '#!/bin/sh\nexec node /app/openclaw.mjs "$@"\n' > /usr/local/bin/openclaw && \
     chmod +x /usr/local/bin/openclaw
-

--- a/phala-deploy/entrypoint.sh
+++ b/phala-deploy/entrypoint.sh
@@ -56,6 +56,29 @@ if [ ! -f "$CONFIG_FILE" ]; then
   fi
 fi
 
+# Bootstrap workspace files from OPENCLAW_WORKSPACE_FILES_B64 (first boot only).
+# Skipped if workspace already has a .git dir (indicates gateway already initialized it).
+WORKSPACE_DIR="/root/.openclaw/workspace"
+if [ -n "$OPENCLAW_WORKSPACE_FILES_B64" ] && [ ! -d "$WORKSPACE_DIR/.git" ]; then
+  echo "Decoding workspace files from OPENCLAW_WORKSPACE_FILES_B64..."
+  mkdir -p "$WORKSPACE_DIR"
+  printf '%s' "$OPENCLAW_WORKSPACE_FILES_B64" | base64 -d | node -e "
+    const fs=require('fs'),path=require('path');
+    const ws=process.argv[1];
+    const files=JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+    for(const[n,c]of Object.entries(files)){
+      const fp=path.resolve(ws,n);
+      if(!fp.startsWith(ws + '/')){
+        throw new Error('Invalid workspace file path: ' + n);
+      }
+      fs.mkdirSync(path.dirname(fp),{recursive:true});
+      fs.writeFileSync(fp,c);
+      console.log('Wrote',fp);
+    }
+  " "$WORKSPACE_DIR"
+  echo "Workspace files written."
+fi
+
 # --- Configure mcporter for Composio MCP proxy ---
 # Reads composio skill config from openclaw.json and writes mcporter config.
 if [ -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Summary

- **Slim image** — remove gogcli, rclone, fuse3, pre-installed plugins (QQBot, DingTalk), saving ~2.6GB and cutting boot time
- **Docker opt-in** — Docker daemon now only starts with `ENABLE_DOCKER=1` (saves ~20s startup for k3s pods that don't need it)
- **Single image target** — merge SSH into base stage, eliminate the full stage; build script produces one image
- **Remove openssh-server** — not needed in k3s pods (kubectl exec replaces SSH)
- **Workspace files bootstrap** — decode `OPENCLAW_WORKSPACE_FILES_B64` in entrypoint on first boot, so both Phala CVM and k3s pods get workspace files without compose command overrides

## Test plan

- [x] Image built and deployed as `ghcr.io/clawdi-ai/openclaw:2026.3.27-k3s.1` (1.63GB)
- [x] k3s pod boots with workspace files from B64 env var
- [x] Phala CVM continues to work with `ENABLE_DOCKER=1`
- [x] E2e verified exec, config read/write, health check against real k3s pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)