### PR TITLE
Fix stale device identity causing gateway RPC auth failure on CVM restarts

### DIFF
--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -77,4 +77,23 @@ describe("device identity crypto helpers", () => {
       });
     });
   });
+
+  it("overwrites stale device.json when MASTER_KEY derivation differs", async () => {
+    await withTempDir("openclaw-device-identity-", async (dir) => {
+      const identityPath = path.join(dir, "device.json");
+
+      // Create a random identity without MASTER_KEY (simulates pre-fix state)
+      const random = loadOrCreateDeviceIdentity(identityPath);
+
+      // Now load with MASTER_KEY — should replace the random identity
+      await withEnvAsync({ MASTER_KEY: "test-master-key" }, async () => {
+        const derived = loadOrCreateDeviceIdentity(identityPath);
+        expect(derived.deviceId).not.toBe(random.deviceId);
+
+        // Reload should return the same derived identity
+        const reloaded = loadOrCreateDeviceIdentity(identityPath);
+        expect(reloaded).toEqual(derived);
+      });
+    });
+  });
 });

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -82,6 +82,45 @@ function deriveIdentityFromMasterKey(masterKey: string): DeviceIdentity {
 export function loadOrCreateDeviceIdentity(
   filePath: string = resolveDefaultIdentityPath(),
 ): DeviceIdentity {
+  const masterKey = typeof process.env.MASTER_KEY === "string" ? process.env.MASTER_KEY.trim() : "";
+
+  // When MASTER_KEY is set, the identity must always match the derivation.
+  // A stale device.json (e.g. randomly generated before the MASTER_KEY fix)
+  // would mismatch the pre-seeded paired.json and break RPC auth on CVMs.
+  if (masterKey) {
+    const expected = deriveIdentityFromMasterKey(masterKey);
+    try {
+      if (fs.existsSync(filePath)) {
+        const raw = fs.readFileSync(filePath, "utf8");
+        const parsed = JSON.parse(raw) as StoredIdentity;
+        if (
+          parsed?.version === 1 &&
+          parsed.deviceId === expected.deviceId &&
+          parsed.publicKeyPem === expected.publicKeyPem
+        ) {
+          return expected;
+        }
+      }
+    } catch {
+      // fall through to write
+    }
+    ensureDir(filePath);
+    const stored: StoredIdentity = {
+      version: 1,
+      deviceId: expected.deviceId,
+      publicKeyPem: expected.publicKeyPem,
+      privateKeyPem: expected.privateKeyPem,
+      createdAtMs: Date.now(),
+    };
+    fs.writeFileSync(filePath, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // best-effort
+    }
+    return expected;
+  }
+
   try {
     if (fs.existsSync(filePath)) {
       const raw = fs.readFileSync(filePath, "utf8");
@@ -121,8 +160,7 @@ export function loadOrCreateDeviceIdentity(
     // fall through to regenerate
   }
 
-  const masterKey = typeof process.env.MASTER_KEY === "string" ? process.env.MASTER_KEY.trim() : "";
-  const identity = masterKey ? deriveIdentityFromMasterKey(masterKey) : generateIdentity();
+  const identity = generateIdentity();
   ensureDir(filePath);
   const stored: StoredIdentity = {
     version: 1,


### PR DESCRIPTION
## Summary

- Fix `loadOrCreateDeviceIdentity()` to validate stored `device.json` against `MASTER_KEY` derivation on every load, not just on first create
- **Root cause**: CVMs deployed before phala.3 had a randomly generated `device.json` that didn't match the MASTER_KEY-derived identity pre-seeded in `paired.json` by the entrypoint. This caused `openclaw agent` to fail with `gateway closed (1000 normal closure)` because the unrecognized device had its operator scopes cleared, and the agent method requires `WRITE_SCOPE`. Meanwhile `gateway status --deep` worked fine since the probe uses `READ_SCOPE` with no device identity.
- When `MASTER_KEY` is set: derive the expected identity upfront, compare with stored `device.json`, and overwrite if they differ. This ensures the CLI device always matches the pre-seeded paired device, eliminating the auth mismatch.
- Add test for the stale device.json overwrite scenario

## Test plan

- [x] `pnpm test -- src/infra/device-identity.test.ts src/infra/device-identity.state-dir.test.ts` — 10/10 pass
- [x] Reproduced in local-mux-e2e: injected stale random `device.json` + reset `paired.json` to MASTER_KEY-only entry, restarted container, verified `device.json` was corrected and `openclaw agent` works without auto-pairing fallback
- [x] `pnpm tsgo` and `oxfmt --check` pass
- [ ] Deploy to staging CVM and verify agent RPC connects without fallback to embedded mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)