### PR TITLE
feat(sessions): auto-generate session title after first exchange

### DIFF
--- a/src/agents/github-copilot-token.ts
+++ b/src/agents/github-copilot-token.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+
+const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
+
+export type CachedCopilotToken = {
+  token: string;
+  /** milliseconds since epoch */
+  expiresAt: number;
+  /** milliseconds since epoch */
+  updatedAt: number;
+};
+
+function resolveCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
+  return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");
+}
+
+function isTokenUsable(cache: CachedCopilotToken, now = Date.now()): boolean {
+  // Keep a small safety margin when checking expiry.
+  return cache.expiresAt - now > 5 * 60 * 1000;
+}
+
+function parseCopilotTokenResponse(value: unknown): {
+  token: string;
+  expiresAt: number;
+} {
+  if (!value || typeof value !== "object") {
+    throw new Error("Unexpected response from GitHub Copilot token endpoint");
+  }
+  const asRecord = value as Record<string, unknown>;
+  const token = asRecord.token;
+  const expiresAt = asRecord.expires_at;
+  if (typeof token !== "string" || token.trim().length === 0) {
+    throw new Error("Copilot token response missing token");
+  }
+
+  // GitHub returns a unix timestamp (seconds), but we defensively accept ms too.
+  // Use a 1e11 threshold so large seconds-epoch values are not misread as ms.
+  let expiresAtMs: number;
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    expiresAtMs = expiresAt < 100_000_000_000 ? expiresAt * 1000 : expiresAt;
+  } else if (typeof expiresAt === "string" && expiresAt.trim().length > 0) {
+    const parsed = Number.parseInt(expiresAt, 10);
+    if (!Number.isFinite(parsed)) {
+      throw new Error("Copilot token response has invalid expires_at");
+    }
+    expiresAtMs = parsed < 100_000_000_000 ? parsed * 1000 : parsed;
+  } else {
+    throw new Error("Copilot token response missing expires_at");
+  }
+
+  return { token, expiresAt: expiresAtMs };
+}
+
+export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
+
+export function deriveCopilotApiBaseUrlFromToken(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // The token returned from the Copilot token endpoint is a semicolon-delimited
+  // set of key/value pairs. One of them is `proxy-ep=...`.
+  const match = trimmed.match(/(?:^|;)\s*proxy-ep=([^;\s]+)/i);
+  const proxyEp = match?.[1]?.trim();
+  if (!proxyEp) {
+    return null;
+  }
+
+  // pi-ai expects converting proxy.* -> api.*
+  // (see upstream getGitHubCopilotBaseUrl).
+  const host = proxyEp.replace(/^https?:\/\//, "").replace(/^proxy\./i, "api.");
+  if (!host) {
+    return null;
+  }
+
+  return `https://${host}`;
+}
+
+export async function resolveCopilotApiToken(params: {
+  githubToken: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  cachePath?: string;
+  loadJsonFileImpl?: (path: string) => unknown;
+  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
+}): Promise<{
+  token: string;
+  expiresAt: number;
+  source: string;
+  baseUrl: string;
+}> {
+  const env = params.env ?? process.env;
+  const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env);
+  const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
+  const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
+  const cached = loadJsonFileFn(cachePath) as CachedCopilotToken | undefined;
+  if (cached && typeof cached.token === "string" && typeof cached.expiresAt === "number") {
+    if (isTokenUsable(cached)) {
+      return {
+        token: cached.token,
+        expiresAt: cached.expiresAt,
+        source: `cache:${cachePath}`,
+        baseUrl: deriveCopilotApiBaseUrlFromToken(cached.token) ?? DEFAULT_COPILOT_API_BASE_URL,
+      };
+    }
+  }
+
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const res = await fetchImpl(COPILOT_TOKEN_URL, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${params.githubToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Copilot token exchange failed: HTTP ${res.status}`);
+  }
+
+  const json = parseCopilotTokenResponse(await res.json());
+  const payload: CachedCopilotToken = {
+    token: json.token,
+    expiresAt: json.expiresAt,
+    updatedAt: Date.now(),
+  };
+  saveJsonFileFn(cachePath, payload);
+
+  return {
+    token: payload.token,
+    expiresAt: payload.expiresAt,
+    source: `fetched:${COPILOT_TOKEN_URL}`,
+    baseUrl: deriveCopilotApiBaseUrlFromToken(payload.token) ?? DEFAULT_COPILOT_API_BASE_URL,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2670,6 +2670,33 @@ export async function runEmbeddedAttempt(
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
 
+        // Auto-generate session title on first exchange (fire-and-forget)
+        const autoTitleSessionKey = params.sessionKey;
+        const autoTitleConfig = params.config;
+        if (
+          autoTitleSessionKey &&
+          params.trigger === "user" &&
+          !aborted &&
+          !promptError &&
+          autoTitleConfig
+        ) {
+          import("../../session-auto-title.js")
+            .then(({ maybeGenerateSessionTitle }) =>
+              maybeGenerateSessionTitle({
+                success: true,
+                trigger: params.trigger,
+                sessionKey: autoTitleSessionKey,
+                sessionId: sessionIdUsed,
+                agentId: hookAgentId ?? params.agentId ?? "main",
+                messages: messagesSnapshot,
+                config: autoTitleConfig,
+              }),
+            )
+            .catch((err) => {
+              log.warn(`session-auto-title failed: ${err}`);
+            });
+        }
+
         // Run agent_end hooks to allow plugins to analyze the conversation
         // This is fire-and-forget, so we don't await
         // Run even on compaction timeout so plugins can log/cleanup

--- a/src/agents/session-auto-title.test.ts
+++ b/src/agents/session-auto-title.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  shouldGenerateTitle,
+  buildTitlePrompt,
+  cleanGeneratedTitle,
+} from "./session-auto-title.js";
+
+describe("shouldGenerateTitle", () => {
+  const base = {
+    success: true,
+    trigger: "user" as string | undefined,
+    sessionKey: "agent:main:main",
+    messages: [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+    ],
+    existingLabel: undefined as string | undefined,
+  };
+
+  it("returns true for first successful user exchange without label", () => {
+    expect(shouldGenerateTitle(base)).toBe(true);
+  });
+
+  it("returns false when success is false", () => {
+    expect(shouldGenerateTitle({ ...base, success: false })).toBe(false);
+  });
+
+  it("returns false for non-user triggers", () => {
+    for (const trigger of ["cron", "heartbeat", "memory", "manual", "overflow"]) {
+      expect(shouldGenerateTitle({ ...base, trigger })).toBe(false);
+    }
+  });
+
+  it("returns false for subagent sessions", () => {
+    expect(shouldGenerateTitle({ ...base, sessionKey: "agent:main:subagent:task1" })).toBe(false);
+  });
+
+  it("returns false for temp sessions", () => {
+    expect(shouldGenerateTitle({ ...base, sessionKey: "temp:slug-gen" })).toBe(false);
+  });
+
+  it("returns false when session already has a label", () => {
+    expect(shouldGenerateTitle({ ...base, existingLabel: "My Topic" })).toBe(false);
+  });
+
+  it("returns false when multiple assistant messages exist", () => {
+    expect(
+      shouldGenerateTitle({
+        ...base,
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi!" },
+          { role: "user", content: "More" },
+          { role: "assistant", content: "Sure" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when no assistant message exists", () => {
+    expect(shouldGenerateTitle({ ...base, messages: [{ role: "user", content: "Hello" }] })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when sessionKey is falsy", () => {
+    expect(shouldGenerateTitle({ ...base, sessionKey: "" })).toBe(false);
+  });
+});
+
+describe("buildTitlePrompt", () => {
+  it("extracts user and assistant content", () => {
+    const prompt = buildTitlePrompt([
+      { role: "user", content: "How do I set up a Telegram bot?" },
+      { role: "assistant", content: "Talk to BotFather first." },
+    ]);
+    expect(prompt).toContain("How do I set up a Telegram bot?");
+    expect(prompt).toContain("Talk to BotFather");
+  });
+
+  it("truncates long content", () => {
+    const prompt = buildTitlePrompt([
+      { role: "user", content: "x".repeat(2000) },
+      { role: "assistant", content: "y".repeat(2000) },
+    ]);
+    expect(prompt.length).toBeLessThan(2000);
+  });
+
+  it("skips tool messages", () => {
+    const prompt = buildTitlePrompt([
+      { role: "user", content: "Search for X" },
+      { role: "tool", content: "result data" },
+      { role: "assistant", content: "I found X." },
+    ]);
+    expect(prompt).not.toContain("result data");
+    expect(prompt).toContain("Search for X");
+  });
+
+  it("handles structured content blocks", () => {
+    const prompt = buildTitlePrompt([
+      { role: "user", content: [{ type: "text", text: "Structured message" }] },
+      { role: "assistant", content: "Reply" },
+    ]);
+    expect(prompt).toContain("Structured message");
+  });
+});
+
+describe("cleanGeneratedTitle", () => {
+  it("strips surrounding quotes", () => {
+    expect(cleanGeneratedTitle('"API Design"')).toBe("API Design");
+    expect(cleanGeneratedTitle("'Bot Setup'")).toBe("Bot Setup");
+  });
+
+  it("truncates to 50 chars", () => {
+    expect(cleanGeneratedTitle("A".repeat(80))!.length).toBeLessThanOrEqual(50);
+  });
+
+  it("trims whitespace", () => {
+    expect(cleanGeneratedTitle("  Hello World  ")).toBe("Hello World");
+  });
+
+  it("returns null for empty input", () => {
+    expect(cleanGeneratedTitle("")).toBeNull();
+    expect(cleanGeneratedTitle("   ")).toBeNull();
+  });
+});
+
+// Integration test for maybeGenerateSessionTitle
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../gateway/session-utils.js", () => ({
+  loadSessionEntry: vi.fn().mockReturnValue({
+    entry: { sessionId: "sess-1", label: undefined },
+  }),
+}));
+
+vi.mock("./simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModelForAgent: vi.fn().mockResolvedValue({
+    selection: { provider: "anthropic", modelId: "claude-sonnet-4-6", agentDir: "/tmp" },
+    model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+    auth: { apiKey: "sk-test", source: "env", mode: "api-key" },
+  }),
+  completeWithPreparedSimpleCompletionModel: vi.fn().mockResolvedValue({
+    role: "assistant",
+    content: [{ type: "text", text: "Telegram Bot Setup" }],
+  }),
+}));
+
+vi.mock("./pi-embedded-utils.js", () => ({
+  extractAssistantText: vi.fn().mockReturnValue("Telegram Bot Setup"),
+}));
+
+describe("maybeGenerateSessionTitle", () => {
+  let maybeGenerateSessionTitle: typeof import("./session-auto-title.js").maybeGenerateSessionTitle;
+  let callGatewayMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ maybeGenerateSessionTitle } = await import("./session-auto-title.js"));
+    const mod = await import("../gateway/call.js");
+    callGatewayMock = mod.callGateway as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it("generates and patches label on first exchange", async () => {
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "How do I set up a Telegram bot?" },
+        { role: "assistant", content: "Talk to BotFather first." },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.patch",
+        params: expect.objectContaining({
+          key: "agent:main:main",
+          label: "Telegram Bot Setup",
+        }),
+      }),
+    );
+  });
+
+  it("skips when trigger is not user", async () => {
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "heartbeat",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when session already has a label", async () => {
+    const { loadSessionEntry } = await import("../gateway/session-utils.js");
+    (loadSessionEntry as ReturnType<typeof vi.fn>).mockReturnValue({
+      entry: { sessionId: "sess-1", label: "Existing" },
+    });
+
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when loadSessionEntry throws", async () => {
+    const { loadSessionEntry } = await import("../gateway/session-utils.js");
+    (loadSessionEntry as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("store not found");
+    });
+
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when sessionId changed (reset race)", async () => {
+    const { loadSessionEntry } = await import("../gateway/session-utils.js");
+    (loadSessionEntry as ReturnType<typeof vi.fn>).mockReturnValue({
+      entry: { sessionId: "old-sess", label: undefined },
+    });
+
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      sessionId: "new-sess",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("retries with time suffix on label collision", async () => {
+    const { loadSessionEntry } = await import("../gateway/session-utils.js");
+    (loadSessionEntry as ReturnType<typeof vi.fn>).mockReturnValue({
+      entry: { sessionId: "sess-1", label: undefined },
+    });
+    callGatewayMock
+      .mockRejectedValueOnce(new Error("label already in use: Telegram Bot Setup"))
+      .mockResolvedValueOnce({});
+
+    await maybeGenerateSessionTitle({
+      success: true,
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+      agentId: "main",
+      messages: [
+        { role: "user", content: "How do I set up a Telegram bot?" },
+        { role: "assistant", content: "Talk to BotFather first." },
+      ],
+      config: {} as unknown as OpenClawConfig,
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    const retryLabel = callGatewayMock.mock.calls[1][0].params.label;
+    expect(retryLabel).toMatch(/^Telegram Bot Setup \(\d{2}:\d{2}\)$/);
+  });
+});

--- a/src/agents/session-auto-title.ts
+++ b/src/agents/session-auto-title.ts
@@ -1,0 +1,202 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { callGateway } from "../gateway/call.js";
+import { loadSessionEntry } from "../gateway/session-utils.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
+import { extractAssistantText } from "./pi-embedded-utils.js";
+import {
+  prepareSimpleCompletionModelForAgent,
+  completeWithPreparedSimpleCompletionModel,
+} from "./simple-completion-runtime.js";
+
+const log = createSubsystemLogger("session-auto-title");
+
+const TITLE_MAX_LENGTH = 50;
+const PROMPT_MAX_CHARS = 1500;
+const TITLE_TIMEOUT_MS = 10_000;
+
+const TITLE_SYSTEM_PROMPT =
+  "Generate a concise title (3-8 words, max 50 characters) for this conversation. " +
+  "Use the same language as the user's message. " +
+  "Return ONLY the title text, no quotes, no explanation, no punctuation wrapping.";
+
+export function shouldGenerateTitle(params: {
+  success: boolean;
+  trigger: string | undefined;
+  sessionKey: string;
+  messages: unknown[];
+  existingLabel: string | undefined;
+}): boolean {
+  if (!params.success) {
+    return false;
+  }
+  if (params.trigger !== "user") {
+    return false;
+  }
+  if (!params.sessionKey) {
+    return false;
+  }
+  if (isSubagentSessionKey(params.sessionKey)) {
+    return false;
+  }
+  if (params.sessionKey.startsWith("temp:")) {
+    return false;
+  }
+  if (params.existingLabel?.trim()) {
+    return false;
+  }
+
+  const assistantCount = params.messages.filter(
+    (m) =>
+      typeof m === "object" && m !== null && (m as Record<string, unknown>).role === "assistant",
+  ).length;
+
+  return assistantCount === 1;
+}
+
+export function buildTitlePrompt(messages: unknown[]): string {
+  const parts: string[] = [];
+  let totalLen = 0;
+
+  for (const msg of messages) {
+    if (typeof msg !== "object" || msg === null) {
+      continue;
+    }
+    const m = msg as Record<string, unknown>;
+    const role = m.role;
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+
+    const content = extractTextFromChatContent(m.content)?.trim() ?? "";
+    if (!content) {
+      continue;
+    }
+
+    const remaining = PROMPT_MAX_CHARS - totalLen;
+    if (remaining <= 0) {
+      break;
+    }
+
+    const truncated = content.length > remaining ? content.slice(0, remaining) + "..." : content;
+    parts.push(`${role}: ${truncated}`);
+    totalLen += truncated.length;
+  }
+
+  return parts.join("\n\n");
+}
+
+export function cleanGeneratedTitle(raw: string): string | null {
+  let cleaned = raw.trim();
+  if (
+    (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+    (cleaned.startsWith("'") && cleaned.endsWith("'"))
+  ) {
+    cleaned = cleaned.slice(1, -1).trim();
+  }
+  if (!cleaned) {
+    return null;
+  }
+  if (cleaned.length > TITLE_MAX_LENGTH) {
+    cleaned = cleaned.slice(0, TITLE_MAX_LENGTH).trim();
+  }
+  return cleaned || null;
+}
+
+export async function maybeGenerateSessionTitle(params: {
+  success: boolean;
+  trigger: string | undefined;
+  sessionKey: string;
+  sessionId: string;
+  agentId: string;
+  messages: unknown[];
+  config: OpenClawConfig;
+}): Promise<void> {
+  let existingLabel: string | undefined;
+  try {
+    const { entry } = loadSessionEntry(params.sessionKey);
+    existingLabel = entry?.label;
+    if (entry?.sessionId && entry.sessionId !== params.sessionId) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  if (
+    !shouldGenerateTitle({
+      success: params.success,
+      trigger: params.trigger,
+      sessionKey: params.sessionKey,
+      messages: params.messages,
+      existingLabel,
+    })
+  ) {
+    return;
+  }
+
+  const conversationText = buildTitlePrompt(params.messages);
+  if (!conversationText) {
+    return;
+  }
+
+  const prepared = await prepareSimpleCompletionModelForAgent({
+    cfg: params.config,
+    agentId: params.agentId,
+  });
+  if ("error" in prepared) {
+    log.debug(`model prep failed: ${prepared.error}`);
+    return;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TITLE_TIMEOUT_MS);
+  let title: string | null = null;
+  try {
+    const response = await completeWithPreparedSimpleCompletionModel({
+      model: prepared.model,
+      auth: prepared.auth,
+      context: {
+        systemPrompt: TITLE_SYSTEM_PROMPT,
+        messages: [{ role: "user" as const, content: conversationText, timestamp: Date.now() }],
+      },
+      options: { maxTokens: 30, signal: controller.signal },
+    });
+
+    title = cleanGeneratedTitle(extractAssistantText(response));
+    if (!title) {
+      return;
+    }
+
+    await callGateway({
+      method: "sessions.patch",
+      params: { key: params.sessionKey, label: title },
+      timeoutMs: 5_000,
+    });
+    log.debug(`auto-title set: "${title}" for ${params.sessionKey}`);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (errMsg.includes("label already in use") && title) {
+      const now = new Date();
+      const suffix = ` (${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")})`;
+      const base = title.slice(0, TITLE_MAX_LENGTH - suffix.length);
+      const fallback = base ? `${base}${suffix}` : null;
+      if (fallback) {
+        try {
+          await callGateway({
+            method: "sessions.patch",
+            params: { key: params.sessionKey, label: fallback },
+            timeoutMs: 5_000,
+          });
+        } catch {
+          // Give up silently
+        }
+      }
+    } else {
+      log.debug(`auto-title failed: ${errMsg}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -1,0 +1,245 @@
+import { complete, type Api, type Model } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
+import { DEFAULT_PROVIDER } from "./defaults.js";
+import {
+  applyLocalNoAuthHeaderOverride,
+  getApiKeyForModel,
+  type ResolvedProviderAuth,
+} from "./model-auth.js";
+import { splitTrailingAuthProfile } from "./model-ref-profile.js";
+import {
+  buildModelAliasIndex,
+  resolveDefaultModelForAgent,
+  resolveModelRefFromString,
+} from "./model-selection.js";
+import { resolveModel } from "./pi-embedded-runner/model.js";
+
+type SimpleCompletionAuthStorage = {
+  setRuntimeApiKey: (provider: string, apiKey: string) => void;
+};
+
+type CompletionRuntimeCredential = {
+  apiKey: string;
+  baseUrl?: string;
+};
+
+type AllowedMissingApiKeyMode = ResolvedProviderAuth["mode"];
+
+export type PreparedSimpleCompletionModel =
+  | {
+      model: Model<Api>;
+      auth: ResolvedProviderAuth;
+    }
+  | {
+      error: string;
+      auth?: ResolvedProviderAuth;
+    };
+
+export type AgentSimpleCompletionSelection = {
+  provider: string;
+  modelId: string;
+  profileId?: string;
+  agentDir: string;
+};
+
+export type PreparedSimpleCompletionModelForAgent =
+  | {
+      selection: AgentSimpleCompletionSelection;
+      model: Model<Api>;
+      auth: ResolvedProviderAuth;
+    }
+  | {
+      error: string;
+      selection?: AgentSimpleCompletionSelection;
+      auth?: ResolvedProviderAuth;
+    };
+
+export function resolveSimpleCompletionSelectionForAgent(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  modelRef?: string;
+}): AgentSimpleCompletionSelection | null {
+  const fallbackRef = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  const modelRef =
+    params.modelRef?.trim() || resolveAgentEffectiveModelPrimary(params.cfg, params.agentId);
+  const split = modelRef ? splitTrailingAuthProfile(modelRef) : null;
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: fallbackRef.provider || DEFAULT_PROVIDER,
+  });
+  const resolved = split
+    ? resolveModelRefFromString({
+        raw: split.model,
+        defaultProvider: fallbackRef.provider || DEFAULT_PROVIDER,
+        aliasIndex,
+      })
+    : null;
+  const provider = resolved?.ref.provider ?? fallbackRef.provider;
+  const modelId = resolved?.ref.model ?? fallbackRef.model;
+  if (!provider || !modelId) {
+    return null;
+  }
+  return {
+    provider,
+    modelId,
+    profileId: split?.profile || undefined,
+    agentDir: resolveAgentDir(params.cfg, params.agentId),
+  };
+}
+
+async function setRuntimeApiKeyForCompletion(params: {
+  authStorage: SimpleCompletionAuthStorage;
+  model: Model<Api>;
+  apiKey: string;
+}): Promise<CompletionRuntimeCredential> {
+  if (params.model.provider === "github-copilot") {
+    const { resolveCopilotApiToken } = await import("./github-copilot-token.js");
+    const copilotToken = await resolveCopilotApiToken({
+      githubToken: params.apiKey,
+    });
+    params.authStorage.setRuntimeApiKey(params.model.provider, copilotToken.token);
+    return {
+      apiKey: copilotToken.token,
+      baseUrl: copilotToken.baseUrl,
+    };
+  }
+  params.authStorage.setRuntimeApiKey(params.model.provider, params.apiKey);
+  return {
+    apiKey: params.apiKey,
+  };
+}
+
+function hasMissingApiKeyAllowance(params: {
+  mode: ResolvedProviderAuth["mode"];
+  allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
+}): boolean {
+  return Boolean(params.allowMissingApiKeyModes?.includes(params.mode));
+}
+
+export async function prepareSimpleCompletionModel(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelId: string;
+  agentDir?: string;
+  profileId?: string;
+  preferredProfile?: string;
+  allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
+}): Promise<PreparedSimpleCompletionModel> {
+  const resolved = resolveModel(params.provider, params.modelId, params.agentDir, params.cfg);
+  if (!resolved.model) {
+    return {
+      error: resolved.error ?? `Unknown model: ${params.provider}/${params.modelId}`,
+    };
+  }
+
+  let auth: ResolvedProviderAuth;
+  try {
+    auth = await getApiKeyForModel({
+      model: resolved.model,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      profileId: params.profileId,
+      preferredProfile: params.preferredProfile,
+    });
+  } catch (err) {
+    return {
+      error: `Auth lookup failed for provider "${resolved.model.provider}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const rawApiKey = auth.apiKey?.trim();
+  if (
+    !rawApiKey &&
+    !hasMissingApiKeyAllowance({
+      mode: auth.mode,
+      allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+    })
+  ) {
+    return {
+      error: `No API key resolved for provider "${resolved.model.provider}" (auth mode: ${auth.mode}).`,
+      auth,
+    };
+  }
+
+  let resolvedApiKey = rawApiKey;
+  let resolvedModel = resolved.model;
+  if (rawApiKey) {
+    const runtimeCredential = await setRuntimeApiKeyForCompletion({
+      authStorage: resolved.authStorage,
+      model: resolved.model,
+      apiKey: rawApiKey,
+    });
+    resolvedApiKey = runtimeCredential.apiKey;
+    const runtimeBaseUrl = runtimeCredential.baseUrl?.trim();
+    if (runtimeBaseUrl) {
+      resolvedModel = {
+        ...resolvedModel,
+        baseUrl: runtimeBaseUrl,
+      };
+    }
+  }
+
+  const resolvedAuth: ResolvedProviderAuth = {
+    ...auth,
+    apiKey: resolvedApiKey,
+  };
+
+  return {
+    model: applyLocalNoAuthHeaderOverride(resolvedModel, resolvedAuth),
+    auth: resolvedAuth,
+  };
+}
+
+export async function prepareSimpleCompletionModelForAgent(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  modelRef?: string;
+  preferredProfile?: string;
+  allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
+}): Promise<PreparedSimpleCompletionModelForAgent> {
+  const selection = resolveSimpleCompletionSelectionForAgent({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    modelRef: params.modelRef,
+  });
+  if (!selection) {
+    return {
+      error: `No model configured for agent ${params.agentId}.`,
+    };
+  }
+  const prepared = await prepareSimpleCompletionModel({
+    cfg: params.cfg,
+    provider: selection.provider,
+    modelId: selection.modelId,
+    agentDir: selection.agentDir,
+    profileId: selection.profileId,
+    preferredProfile: params.preferredProfile,
+    allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+  });
+  if ("error" in prepared) {
+    return {
+      ...prepared,
+      selection,
+    };
+  }
+  return {
+    selection,
+    model: prepared.model,
+    auth: prepared.auth,
+  };
+}
+
+export async function completeWithPreparedSimpleCompletionModel(params: {
+  model: Model<Api>;
+  auth: ResolvedProviderAuth;
+  context: Parameters<typeof complete>[1];
+  options?: Omit<Parameters<typeof complete>[2], "apiKey">;
+}) {
+  return await complete(params.model, params.context, {
+    ...params.options,
+    apiKey: params.auth.apiKey,
+  });
+}

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -660,6 +660,33 @@ describe("deriveSessionTitle", () => {
     } as SessionEntry;
     expect(deriveSessionTitle(entry)).toBe("Actual Subject");
   });
+
+  test("prefers label over subject and firstUserMessage", () => {
+    const entry = {
+      sessionId: "abc123",
+      label: "API Design Discussion",
+      subject: "General",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "Hello there")).toBe("API Design Discussion");
+  });
+
+  test("displayName wins over label", () => {
+    const entry = {
+      sessionId: "abc123",
+      displayName: "Manual Name",
+      label: "Auto Title",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Manual Name");
+  });
+
+  test("ignores empty label and falls through to subject", () => {
+    const entry = {
+      sessionId: "abc123",
+      label: "   ",
+      subject: "Fallback Subject",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Fallback Subject");
+  });
 });
 
 describe("listSessionsFromStore search", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -161,6 +161,10 @@ export function deriveSessionTitle(
     return entry.displayName.trim();
   }
 
+  if (entry.label?.trim()) {
+    return entry.label.trim();
+  }
+
   if (entry.subject?.trim()) {
     return entry.subject.trim();
   }


### PR DESCRIPTION
## Summary

- Auto-generate a concise LLM-powered session title after the first user+assistant exchange
- Write the title to the session's `label` field via `sessions.patch` RPC (auto-broadcasts WS notification to frontend)
- Add `label` to `deriveSessionTitle()` priority chain so titles appear in TUI/ACP/WebChat

## How it works

1. After the first successful user reply in `attempt.ts`, a fire-and-forget call triggers `maybeGenerateSessionTitle()`
2. Guard checks: only `trigger === "user"`, first exchange (`assistantCount === 1`), no existing label, not subagent/temp/cron
3. Uses `prepareSimpleCompletionModelForAgent` for a lightweight one-shot LLM call (no full agent runtime, no recursion risk)
4. Prompt instructs: "Generate title in the same language as the user's message"
5. Writes label via `callGateway("sessions.patch")` — uniqueness collision retries with `(HH:MM)` suffix

## Files

| File | Change |
|------|--------|
| `src/agents/session-auto-title.ts` | New — core logic |
| `src/agents/session-auto-title.test.ts` | New — 23 tests |
| `src/agents/simple-completion-runtime.ts` | Ported from upstream — lightweight LLM API |
| `src/agents/github-copilot-token.ts` | Ported from upstream — dep of above |
| `src/gateway/session-utils.ts` | +4 lines — label in deriveSessionTitle |
| `src/gateway/session-utils.test.ts` | +18 lines — label priority tests |
| `src/agents/pi-embedded-runner/run/attempt.ts` | +15 lines — fire-and-forget wiring |

## Test plan

- [x] 23 unit tests covering guards, prompt building, title cleaning, collision retry, integration
- [x] `pnpm test -- src/agents/session-auto-title.test.ts` — all pass
- [x] `pnpm tsgo` — zero type errors on touched files
- [x] `pnpm format` — clean
- [ ] Manual: start a new session, send one message, verify label appears in session list

Ref: openclaw/openclaw#56308

🤖 Generated with [Claude Code](https://claude.com/claude-code)