### PR TITLE
Fix: move Clawdi plugin install to phala-deploy/Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,10 +232,6 @@ ENV NODE_ENV=production
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
-# Pre-install the Clawdi platform plugin (RPCs, Redpill provider, built-in skills).
-ARG CLAWDI_PLUGIN_VERSION="latest"
-RUN node /app/openclaw.mjs plugins install "@clawdi/openclaw-plugin@${CLAWDI_PLUGIN_VERSION}"
-
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #

--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -98,6 +98,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.npm /tmp/* /usr/include
 
+# Pre-install the Clawdi platform plugin (RPCs, Redpill provider, built-in skills).
+ARG CLAWDI_PLUGIN_VERSION="latest"
+RUN openclaw plugins install "@clawdi/openclaw-plugin@${CLAWDI_PLUGIN_VERSION}"
+
 # --- Stage 3: Dev image (openclaw via bind mount) ---
 FROM base-prereqs AS dev
 


### PR DESCRIPTION
## Summary
- Move `ARG CLAWDI_PLUGIN_VERSION` and Clawdi plugin pre-install from root `Dockerfile` (community image) to `phala-deploy/Dockerfile` (Phala deployment image) where it belongs
- Remove fork-maintained skills (`composio`, `polymarket`, `x-api-readonly`) now shipped inside the `@clawdi/openclaw-plugin` package

## Test plan
- [ ] Build `phala-deploy/Dockerfile` and verify Clawdi plugin is installed
- [ ] Build root `Dockerfile` and verify it remains unchanged (no Clawdi plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)