### PR TITLE
phala-deploy: rm openclaw.json after plugin install

### DIFF
--- a/phala-deploy/Dockerfile
+++ b/phala-deploy/Dockerfile
@@ -100,7 +100,8 @@ RUN apt-get update && \
 
 # Pre-install the Clawdi platform plugin (RPCs, Redpill provider, built-in skills).
 ARG CLAWDI_PLUGIN_VERSION="latest"
-RUN openclaw plugins install "@clawdi/openclaw-plugin@${CLAWDI_PLUGIN_VERSION}"
+RUN openclaw plugins install "@clawdi/openclaw-plugin@${CLAWDI_PLUGIN_VERSION}" && \
+    rm -f /root/.openclaw/openclaw.json
 
 # --- Stage 3: Dev image (openclaw via bind mount) ---
 FROM base-prereqs AS dev


### PR DESCRIPTION
## Summary
- Remove `/root/.openclaw/openclaw.json` after plugin install to prevent default config from interfering with runtime configuration

## Changes
- `phala-deploy/Dockerfile`: append `rm -f /root/.openclaw/openclaw.json` after `openclaw plugins install`
- No changes to backend or entrypoint

## Test plan
- [ ] Build phala.10 image and verify plugin loads correctly
- [ ] Confirm `/root/.openclaw/openclaw.json` does not exist in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)