### PR TITLE
fix: mux-server compute Discord wasMentioned from message.mentions

### DIFF
--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -1133,6 +1133,9 @@ const stmtInsertAuditLog = db.prepare(`
 
 const idempotencyInflight = new Map<string, InflightEntry>();
 let discordGatewayReady = false;
+// Bot's own user ID, extracted from the Discord gateway READY event.
+// Used to compute wasMentioned for inbound messages.
+let discordBotSelfId: string | null = null;
 const discordChannelInfoCache = new Map<
   string,
   {
@@ -5174,6 +5177,16 @@ async function forwardDiscordMessageToTenant(params: {
     return Number.isFinite(timestampRaw) ? Math.trunc(timestampRaw) : Date.now();
   })();
 
+  // Compute wasMentioned from Discord message.mentions array.
+  let wasMentioned = false;
+  if (discordBotSelfId) {
+    const mentions = Array.isArray(params.message.mentions) ? params.message.mentions : [];
+    wasMentioned = mentions.some(
+      (m: unknown) =>
+        asRecord(m) != null && readNonEmptyString(asRecord(m)?.id) === discordBotSelfId,
+    );
+  }
+
   const payload = buildDiscordInboundEnvelope({
     messageId: params.messageId,
     sessionKey,
@@ -5189,6 +5202,7 @@ async function forwardDiscordMessageToTenant(params: {
     rawMessage: params.message,
     media: inboundMedia.media,
     attachments: inboundMedia.attachments,
+    wasMentioned,
   });
   const payloadWithIdentity = {
     ...payload,
@@ -7530,9 +7544,15 @@ async function runDiscordGatewayDmSession(): Promise<void> {
         const ready = asRecord(frame.d);
         discordGatewayReady = true;
         discordRuntimeHealth.gatewayReadyAtMs = Date.now();
+        const readyUser = asRecord(ready?.user);
+        const selfId = readNonEmptyString(readyUser?.id);
+        if (selfId) {
+          discordBotSelfId = selfId;
+        }
         log({
           type: "discord_gateway_dm_ready",
           sessionId: readNonEmptyString(ready?.session_id) ?? null,
+          botSelfId: discordBotSelfId,
         });
         return;
       }
@@ -9329,6 +9349,24 @@ server.listen(port, host, async () => {
     });
   }
   if (discordInboundEnabled) {
+    // Best-effort fetch of bot's own user ID for wasMentioned computation.
+    // The gateway READY event also sets this, but the polling path needs it too.
+    if (!discordBotSelfId) {
+      try {
+        const { response, result } = await discordRequest({
+          method: "GET",
+          path: "/users/@me",
+        });
+        if (response.ok) {
+          const selfId = readNonEmptyString(result.id);
+          if (selfId) {
+            discordBotSelfId = selfId;
+          }
+        }
+      } catch {
+        // Best-effort — wasMentioned will stay false without it.
+      }
+    }
     log({
       type: "discord_inbound_started",
       tenantTargetCount,
@@ -9337,6 +9375,7 @@ server.listen(port, host, async () => {
       bootstrapLatest: discordBootstrapLatest,
       gatewayDmEnabled: discordGatewayDmEnabled,
       gatewayGuildEnabled: discordGatewayGuildEnabled,
+      botSelfId: discordBotSelfId,
       gatewayIntents:
         Number.isFinite(discordGatewayIntents) && discordGatewayIntents > 0
           ? Math.trunc(discordGatewayIntents)

--- a/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
+++ b/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
@@ -120,13 +120,15 @@ describe("Discord mux round trip", () => {
           }
 
           discord.registerGuildChannel({ guildId, channelId });
+          // Include bot in mentions so the message passes requireMention gating.
           discord.enqueueGuildMessage({
             guildId,
             channelId,
             messageId: "9101",
-            content: inboundText,
+            content: `<@${discord.botUserId}> ${inboundText}`,
             authorId: userId,
             username: "guild-user",
+            mentions: [{ id: discord.botUserId, username: "integration-bot", bot: true }],
           });
 
           await harness.openai.waitForRequest(
@@ -201,9 +203,10 @@ describe("Discord mux round trip", () => {
             guildId,
             channelId: threadId,
             messageId: "9201",
-            content: inboundText,
+            content: `<@${discord.botUserId}> ${inboundText}`,
             authorId: userId,
             username: "thread-user",
+            mentions: [{ id: discord.botUserId, username: "integration-bot", bot: true }],
           });
 
           await harness.openai.waitForRequest(
@@ -239,4 +242,77 @@ describe("Discord mux round trip", () => {
     },
     60_000,
   );
+
+  test("drops a Discord guild message when bot is not mentioned (requireMention default)", async () => {
+    const guildId = "9001";
+    const channelId = "777001";
+    const userId = "4242";
+    const mentionedText = "mentioned hello";
+    const unmatchedText = "unmatched hello without mention";
+    const expectedReply = "DISCORD_MENTION_GATE_OK";
+
+    await withMuxOpenClawHarness(
+      {
+        channel: "discord",
+        chatId: guildId,
+        claimedSessionKey: `agent:main:discord:channel:${channelId}`,
+        pairingRouteKey: `discord:default:guild:${guildId}`,
+        llmReplyText: expectedReply,
+        resolutionMode: "session-first",
+        minimalGateway: false,
+        discordGatewayGuildEnabled: true,
+      },
+      async (harness) => {
+        const discord = harness.discord;
+        expect(discord).toBeDefined();
+        if (!discord) {
+          throw new Error("discord harness not available");
+        }
+
+        discord.registerGuildChannel({ guildId, channelId });
+
+        // Send a guild message WITHOUT mentioning the bot — should be silently dropped.
+        discord.enqueueGuildMessage({
+          guildId,
+          channelId,
+          messageId: "9301",
+          content: unmatchedText,
+          authorId: userId,
+          username: "guild-user",
+        });
+
+        // Give the mux-server time to forward the un-mentioned message.
+        await new Promise((r) => setTimeout(r, 2_000));
+
+        // The un-mentioned message should NOT reach the LLM.
+        const llmHit = harness.openai.requests.find((r) => r.lastUserText.includes(unmatchedText));
+        expect(llmHit).toBeUndefined();
+
+        // Now send a message WITH the bot mentioned — should go through.
+        discord.enqueueGuildMessage({
+          guildId,
+          channelId,
+          messageId: "9302",
+          content: `<@${discord.botUserId}> ${mentionedText}`,
+          authorId: userId,
+          username: "guild-user",
+          mentions: [{ id: discord.botUserId, username: "integration-bot", bot: true }],
+        });
+
+        await harness.openai.waitForRequest(
+          (request) => request.lastUserText.includes(mentionedText),
+          10_000,
+        );
+
+        const outbound = await discord.waitForRequest(
+          (request) =>
+            request.kind === "sendMessage" &&
+            request.channelId === channelId &&
+            request.body.content === expectedReply,
+          10_000,
+        );
+        expect(outbound).toBeDefined();
+      },
+    );
+  }, 60_000);
 });

--- a/phala-deploy/integration-test/fake-discord.ts
+++ b/phala-deploy/integration-test/fake-discord.ts
@@ -58,6 +58,8 @@ function toStringId(value: unknown): string {
 
 export class FakeDiscordApi {
   readonly requests: FakeDiscordRequest[] = [];
+  /** Bot's own user ID, included in the gateway READY payload. */
+  readonly botUserId = "999888777";
 
   private readonly pendingMessagesByChannel = new Map<string, FakeDiscordInboundMessage[]>();
   private readonly dmChannelsByUser = new Map<string, string>();
@@ -162,6 +164,7 @@ export class FakeDiscordApi {
     authorId: string;
     timestamp?: string;
     username?: string;
+    mentions?: Array<{ id: string; username?: string; bot?: boolean }>;
   }): void {
     const channel = this.channels.get(params.channelId);
     const thread =
@@ -185,7 +188,7 @@ export class FakeDiscordApi {
         },
         ...(thread ? { thread } : {}),
         attachments: [],
-        mentions: [],
+        mentions: params.mentions ?? [],
         mention_roles: [],
         timestamp: params.timestamp ?? "2026-01-01T00:00:00.000Z",
       },
@@ -242,7 +245,10 @@ export class FakeDiscordApi {
             op: 0,
             t: "READY",
             s: 1,
-            d: { session_id: "fake-discord-session" },
+            d: {
+              session_id: "fake-discord-session",
+              user: { id: this.botUserId, username: "integration-bot", bot: true },
+            },
           }),
         );
         this.flushGatewayFrames();
@@ -276,6 +282,12 @@ export class FakeDiscordApi {
     if (method === "GET" && requestUrl.pathname === "/gateway/bot") {
       res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
       res.end(JSON.stringify({ url: this.url.replace(/^http/i, "ws") + "/gateway" }));
+      return;
+    }
+
+    if (method === "GET" && requestUrl.pathname === "/users/@me") {
+      res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      res.end(JSON.stringify({ id: this.botUserId, username: "integration-bot", bot: true }));
       return;
     }
 

--- a/phala-deploy/integration-test/mux-openclaw-harness.ts
+++ b/phala-deploy/integration-test/mux-openclaw-harness.ts
@@ -192,12 +192,8 @@ function buildHarnessConfig(params: {
                 allowFrom: ["*"],
                 groupPolicy: "open",
                 mux: { enabled: true, timeoutMs: 10_000 },
-                // requireMention must be false: the mux-server does not yet
-                // forward `wasMentioned` from Discord message metadata, so
-                // mention gating silently drops all guild messages.  The
-                // production deploy template also defaults to false.
                 guilds: {
-                  "*": { requireMention: false },
+                  "*": {},
                 },
               },
             }


### PR DESCRIPTION
## Summary

- Compute `wasMentioned` from Discord `message.mentions` in `forwardDiscordMessageToTenant` so mention-gated guild channels work correctly
- Extract bot self-user ID from Discord gateway READY event and `/users/@me` startup fetch
- Remove `requireMention: false` workaround from integration test harness — default `true` now works

Fixes Clawdi-AI/clawdi#335

## Test plan

- [x] Existing Discord DM round-trip tests pass (session-first + target-first)
- [x] Guild channel round-trip tests pass with bot mention included
- [x] Thread round-trip tests pass with bot mention included
- [x] New test: guild message WITHOUT mention is silently dropped
- [x] New test: guild message WITH mention goes through
- [x] mux-envelope unit tests pass (11/11)
- [x] mux-http gateway tests pass (39/39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)