### PR TITLE
Fix gateway token derivation for dash-prefixed master keys

### DIFF
--- a/phala-deploy/entrypoint.sh
+++ b/phala-deploy/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$MASTER_KEY" ]; then
       const c = require('crypto');
       const key = c.hkdfSync('sha256', process.argv[1], '', process.argv[2], 32);
       process.stdout.write(Buffer.from(key).toString('base64'));
-    " "$MASTER_KEY" "$1"
+    " -- "$MASTER_KEY" "$1"
   }
 
   GATEWAY_AUTH_TOKEN=$(derive_key gateway-auth-token | tr -d '/+=' | head -c 32)

--- a/phala-deploy/gen-cvm-config.sh
+++ b/phala-deploy/gen-cvm-config.sh
@@ -38,7 +38,7 @@ GATEWAY_AUTH_TOKEN=$(node -e "
   const c = require('crypto');
   const key = c.hkdfSync('sha256', process.argv[1], '', 'gateway-auth-token', 32);
   process.stdout.write(Buffer.from(key).toString('base64'));
-" "$MASTER_KEY" | tr -d '/+=' | head -c 32)
+" -- "$MASTER_KEY" | tr -d '/+=' | head -c 32)
 
 # inboundUrl uses ${DSTACK_APP_ID} / ${DSTACK_GATEWAY_DOMAIN} placeholders —
 # resolved by the config loader's env-substitution (vars forwarded via docker-compose.yml)

--- a/phala-deploy/local-mux-e2e/scripts/up.sh
+++ b/phala-deploy/local-mux-e2e/scripts/up.sh
@@ -41,7 +41,7 @@ GATEWAY_AUTH_TOKEN=$(node -e "
   const c = require('crypto');
   const key = c.hkdfSync('sha256', process.argv[1], '', 'gateway-auth-token', 32);
   process.stdout.write(Buffer.from(key).toString('base64'));
-" "$MASTER_KEY" | tr -d '/+=' | head -c 32)
+" -- "$MASTER_KEY" | tr -d '/+=' | head -c 32)
 
 # Static mock JWT: satisfies pi-ai's extractAccountId for codex oauth-shaped models.
 CODEX_MOCK_JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9zdWIyYXBpX3Byb3h5In0sImV4cCI6OTk5OTk5OTk5OX0.c3ViMmFwaQ"


### PR DESCRIPTION
## Summary
- pass Node CLI args after \ when deriving the gateway auth token
- fix the same derivation pattern in the deployment entrypoint, config generator, and local mux e2e helper
- prevent fallback to \ when \ begins with a dash

## Verification
- reproduced the broken derivation with a dash-prefixed master key before the fix
- verified the patched derivation returns the expected token for the same master key
- hot patched a live pod with the corrected token and confirmed \ changed from 401 to 200
