### PR TITLE
fix: move Discord mention detection from mux-server to gateway

### DIFF
--- a/mux-server/src/mux-envelope.ts
+++ b/mux-server/src/mux-envelope.ts
@@ -596,6 +596,7 @@ export function buildDiscordInboundEnvelope(params: {
   media: unknown;
   attachments: MuxInboundAttachment[];
   botUserId?: string | null;
+  wasMentioned?: boolean;
 }): MuxInboundEnvelope {
   const raw = {
     message: params.rawMessage,
@@ -632,6 +633,10 @@ export function buildDiscordInboundEnvelope(params: {
   };
   if (params.attachments.length > 0) {
     payload.attachments = params.attachments;
+  }
+  // Backward compat: old gateways read payload.wasMentioned directly.
+  if (params.wasMentioned != null) {
+    payload.wasMentioned = params.wasMentioned;
   }
   return payload;
 }

--- a/mux-server/src/mux-envelope.ts
+++ b/mux-server/src/mux-envelope.ts
@@ -595,7 +595,7 @@ export function buildDiscordInboundEnvelope(params: {
   rawMessage: unknown;
   media: unknown;
   attachments: MuxInboundAttachment[];
-  wasMentioned?: boolean;
+  botUserId?: string | null;
 }): MuxInboundEnvelope {
   const raw = {
     message: params.rawMessage,
@@ -626,14 +626,12 @@ export function buildDiscordInboundEnvelope(params: {
       discord: {
         media: params.media,
         rawMessage: params.rawMessage,
+        ...(params.botUserId ? { botUserId: params.botUserId } : {}),
       },
     },
   };
   if (params.attachments.length > 0) {
     payload.attachments = params.attachments;
-  }
-  if (params.wasMentioned != null) {
-    payload.wasMentioned = params.wasMentioned;
   }
   return payload;
 }

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -5177,6 +5177,23 @@ async function forwardDiscordMessageToTenant(params: {
     return Number.isFinite(timestampRaw) ? Math.trunc(timestampRaw) : Date.now();
   })();
 
+  // Best-effort wasMentioned for backward compat with old gateways that
+  // don't yet compute mentions from raw data.  New gateways ignore this
+  // when channelData.discord.botUserId is present.
+  let legacyWasMentioned = false;
+  if (discordBotSelfId) {
+    const mentions = Array.isArray(params.message.mentions) ? params.message.mentions : [];
+    legacyWasMentioned = mentions.some(
+      (m: unknown) =>
+        asRecord(m) != null && readNonEmptyString(asRecord(m)?.id) === discordBotSelfId,
+    );
+    if (!legacyWasMentioned && params.body) {
+      legacyWasMentioned =
+        params.body.includes(`<@${discordBotSelfId}>`) ||
+        params.body.includes(`<@!${discordBotSelfId}>`);
+    }
+  }
+
   const payload = buildDiscordInboundEnvelope({
     messageId: params.messageId,
     sessionKey,
@@ -5193,6 +5210,7 @@ async function forwardDiscordMessageToTenant(params: {
     media: inboundMedia.media,
     attachments: inboundMedia.attachments,
     botUserId: discordBotSelfId,
+    wasMentioned: legacyWasMentioned,
   });
   const payloadWithIdentity = {
     ...payload,

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -5177,25 +5177,6 @@ async function forwardDiscordMessageToTenant(params: {
     return Number.isFinite(timestampRaw) ? Math.trunc(timestampRaw) : Date.now();
   })();
 
-  // Compute wasMentioned from Discord message.mentions array, with a
-  // body-text fallback.  The mentions array is the primary signal, but
-  // edge cases (MESSAGE_CONTENT intent races, webhook/forwarded messages,
-  // or API inconsistencies) can leave it empty even when the body text
-  // contains a <@BOT_ID> mention.  Checking the body text catches those.
-  let wasMentioned = false;
-  if (discordBotSelfId) {
-    const mentions = Array.isArray(params.message.mentions) ? params.message.mentions : [];
-    wasMentioned = mentions.some(
-      (m: unknown) =>
-        asRecord(m) != null && readNonEmptyString(asRecord(m)?.id) === discordBotSelfId,
-    );
-    if (!wasMentioned && params.body) {
-      wasMentioned =
-        params.body.includes(`<@${discordBotSelfId}>`) ||
-        params.body.includes(`<@!${discordBotSelfId}>`);
-    }
-  }
-
   const payload = buildDiscordInboundEnvelope({
     messageId: params.messageId,
     sessionKey,
@@ -5211,7 +5192,7 @@ async function forwardDiscordMessageToTenant(params: {
     rawMessage: params.message,
     media: inboundMedia.media,
     attachments: inboundMedia.attachments,
-    wasMentioned,
+    botUserId: discordBotSelfId,
   });
   const payloadWithIdentity = {
     ...payload,

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -5177,7 +5177,11 @@ async function forwardDiscordMessageToTenant(params: {
     return Number.isFinite(timestampRaw) ? Math.trunc(timestampRaw) : Date.now();
   })();
 
-  // Compute wasMentioned from Discord message.mentions array.
+  // Compute wasMentioned from Discord message.mentions array, with a
+  // body-text fallback.  The mentions array is the primary signal, but
+  // edge cases (MESSAGE_CONTENT intent races, webhook/forwarded messages,
+  // or API inconsistencies) can leave it empty even when the body text
+  // contains a <@BOT_ID> mention.  Checking the body text catches those.
   let wasMentioned = false;
   if (discordBotSelfId) {
     const mentions = Array.isArray(params.message.mentions) ? params.message.mentions : [];
@@ -5185,6 +5189,11 @@ async function forwardDiscordMessageToTenant(params: {
       (m: unknown) =>
         asRecord(m) != null && readNonEmptyString(asRecord(m)?.id) === discordBotSelfId,
     );
+    if (!wasMentioned && params.body) {
+      wasMentioned =
+        params.body.includes(`<@${discordBotSelfId}>`) ||
+        params.body.includes(`<@!${discordBotSelfId}>`);
+    }
   }
 
   const payload = buildDiscordInboundEnvelope({

--- a/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
+++ b/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
@@ -315,4 +315,63 @@ describe("Discord mux round trip", () => {
       },
     );
   }, 60_000);
+
+  test("detects mention from body text when mentions array is empty", async () => {
+    const guildId = "9001";
+    const channelId = "777001";
+    const userId = "4242";
+    const inboundText = "body-mention hello";
+    const expectedReply = "DISCORD_BODY_MENTION_OK";
+
+    await withMuxOpenClawHarness(
+      {
+        channel: "discord",
+        chatId: guildId,
+        claimedSessionKey: `agent:main:discord:channel:${channelId}`,
+        pairingRouteKey: `discord:default:guild:${guildId}`,
+        llmReplyText: expectedReply,
+        resolutionMode: "session-first",
+        minimalGateway: false,
+        discordGatewayGuildEnabled: true,
+      },
+      async (harness) => {
+        const discord = harness.discord;
+        expect(discord).toBeDefined();
+        if (!discord) {
+          throw new Error("discord harness not available");
+        }
+
+        discord.registerGuildChannel({ guildId, channelId });
+
+        // Send a guild message WITH <@BOT_ID> in the body text but WITHOUT
+        // the bot in the mentions array.  This simulates edge cases where
+        // Discord does not populate the mentions array (e.g. MESSAGE_CONTENT
+        // intent race, API inconsistency, or forwarded/webhook messages).
+        discord.enqueueGuildMessage({
+          guildId,
+          channelId,
+          messageId: "9401",
+          content: `<@${discord.botUserId}> ${inboundText}`,
+          authorId: userId,
+          username: "guild-user",
+          // Deliberately omit mentions array — the mux-server must detect
+          // the mention from the body text as a fallback.
+        });
+
+        await harness.openai.waitForRequest(
+          (request) => request.lastUserText.includes(inboundText),
+          10_000,
+        );
+
+        const outbound = await discord.waitForRequest(
+          (request) =>
+            request.kind === "sendMessage" &&
+            request.channelId === channelId &&
+            request.body.content === expectedReply,
+          10_000,
+        );
+        expect(outbound).toBeDefined();
+      },
+    );
+  }, 60_000);
 });

--- a/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
+++ b/phala-deploy/integration-test/discord.mux-roundtrip.e2e.test.ts
@@ -344,9 +344,9 @@ describe("Discord mux round trip", () => {
         discord.registerGuildChannel({ guildId, channelId });
 
         // Send a guild message WITH <@BOT_ID> in the body text but WITHOUT
-        // the bot in the mentions array.  This simulates edge cases where
-        // Discord does not populate the mentions array (e.g. MESSAGE_CONTENT
-        // intent race, API inconsistency, or forwarded/webhook messages).
+        // the bot in the mentions array.  The mux-server forwards the raw
+        // Discord data; the gateway computes wasMentioned using the same
+        // matchesMentionWithExplicit logic as the non-mux adapter.
         discord.enqueueGuildMessage({
           guildId,
           channelId,
@@ -354,8 +354,8 @@ describe("Discord mux round trip", () => {
           content: `<@${discord.botUserId}> ${inboundText}`,
           authorId: userId,
           username: "guild-user",
-          // Deliberately omit mentions array — the mux-server must detect
-          // the mention from the body text as a fallback.
+          // Deliberately omit mentions array — the gateway must detect the
+          // mention via body-text regex from the raw Discord data.
         });
 
         await harness.openai.waitForRequest(

--- a/src/gateway/mux-http.ts
+++ b/src/gateway/mux-http.ts
@@ -1021,38 +1021,51 @@ async function resolveDiscordMuxAccess(params: {
   }
 
   // Compute wasMentioned from raw Discord data — same logic as non-mux adapter.
-  // The mux-server forwards the raw message (including mentions array) and the
-  // bot's own user ID; the gateway owns all mention-gating decisions.
+  // New mux-servers pass channelData.discord.botUserId + the raw message;
+  // old mux-servers only pass payload.wasMentioned.  When botUserId is
+  // present the gateway owns the decision; otherwise fall back to the
+  // pre-computed envelope value.
   const discordData = asMuxRecord(params.channelData?.discord);
   const rawMessage = asMuxRecord(discordData?.rawMessage);
   const botUserId = readMuxNonEmptyString(discordData?.botUserId);
-  const rawMentions = Array.isArray(rawMessage?.mentions) ? rawMessage.mentions : [];
-  const rawMentionRoles = Array.isArray(rawMessage?.mention_roles) ? rawMessage.mention_roles : [];
-  const mentionEveryone = rawMessage?.mention_everyone === true;
 
-  // Check both the structured mentions array and the body text for Discord's
-  // <@ID>/<@!ID> syntax.  The array is the canonical source, but edge cases
-  // (webhook/forwarded messages, API inconsistencies) can leave it empty even
-  // when the body text contains the mention.
-  const mentionInArray = rawMentions.some(
-    (m: unknown) =>
-      asMuxRecord(m) != null && readMuxNonEmptyString(asMuxRecord(m)?.id) === botUserId,
-  );
-  const mentionInBody =
-    params.body.includes(`<@${botUserId}>`) || params.body.includes(`<@!${botUserId}>`);
-  const explicitlyMentioned = Boolean(botUserId && (mentionInArray || mentionInBody));
-  const hasAnyMention =
-    rawMentions.length > 0 || rawMentionRoles.length > 0 || mentionEveryone || mentionInBody;
-  const mentionRegexes = buildMentionRegexes(params.cfg);
-  const wasMentioned = matchesMentionWithExplicit({
-    text: params.body,
-    mentionRegexes,
-    explicit: {
-      hasAnyMention,
-      isExplicitlyMentioned: explicitlyMentioned,
-      canResolveExplicit: Boolean(botUserId),
-    },
-  });
+  let wasMentioned: boolean;
+  let hasAnyMention: boolean;
+  let canDetectMention: boolean;
+
+  if (botUserId) {
+    // New path: compute from raw Discord data.
+    const rawMentions = Array.isArray(rawMessage?.mentions) ? rawMessage.mentions : [];
+    const rawMentionRoles = Array.isArray(rawMessage?.mention_roles)
+      ? rawMessage.mention_roles
+      : [];
+    const mentionEveryone = rawMessage?.mention_everyone === true;
+    const mentionInArray = rawMentions.some(
+      (m: unknown) =>
+        asMuxRecord(m) != null && readMuxNonEmptyString(asMuxRecord(m)?.id) === botUserId,
+    );
+    const mentionInBody =
+      params.body.includes(`<@${botUserId}>`) || params.body.includes(`<@!${botUserId}>`);
+    const explicitlyMentioned = mentionInArray || mentionInBody;
+    hasAnyMention =
+      rawMentions.length > 0 || rawMentionRoles.length > 0 || mentionEveryone || mentionInBody;
+    const mentionRegexes = buildMentionRegexes(params.cfg);
+    wasMentioned = matchesMentionWithExplicit({
+      text: params.body,
+      mentionRegexes,
+      explicit: {
+        hasAnyMention,
+        isExplicitlyMentioned: explicitlyMentioned,
+        canResolveExplicit: true,
+      },
+    });
+    canDetectMention = true;
+  } else {
+    // Legacy path: old mux-server without botUserId — use envelope value.
+    wasMentioned = params.payload.wasMentioned === true;
+    hasAnyMention = wasMentioned;
+    canDetectMention = true;
+  }
 
   const requireMention = resolveDiscordShouldRequireMention({
     isGuildMessage: true,
@@ -1063,7 +1076,7 @@ async function resolveDiscordMuxAccess(params: {
   const mentionGate = resolveMentionGatingWithBypass({
     isGroup: true,
     requireMention,
-    canDetectMention: Boolean(botUserId),
+    canDetectMention,
     wasMentioned,
     hasAnyMention,
     allowTextCommands: true,

--- a/src/gateway/mux-http.ts
+++ b/src/gateway/mux-http.ts
@@ -10,6 +10,7 @@ import {
 } from "../auto-reply/commands-registry.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.types.js";
 import { dispatchInboundMessage } from "../auto-reply/dispatch.js";
+import { buildMentionRegexes, matchesMentionWithExplicit } from "../auto-reply/reply/mentions.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { resolveReplyToMode } from "../auto-reply/reply/reply-threading.js";
@@ -897,7 +898,6 @@ async function resolveDiscordMuxAccess(params: {
   channelData: Record<string, unknown> | undefined;
   body: string;
   chatType: string;
-  wasMentioned: boolean;
 }): Promise<MuxAccessResult> {
   const discordCfg = params.cfg.channels?.discord ?? {};
   const hasControlCommandInMessage = hasControlCommand(params.body, params.cfg, {});
@@ -1020,6 +1020,40 @@ async function resolveDiscordMuxAccess(params: {
     return { allowed: false };
   }
 
+  // Compute wasMentioned from raw Discord data — same logic as non-mux adapter.
+  // The mux-server forwards the raw message (including mentions array) and the
+  // bot's own user ID; the gateway owns all mention-gating decisions.
+  const discordData = asMuxRecord(params.channelData?.discord);
+  const rawMessage = asMuxRecord(discordData?.rawMessage);
+  const botUserId = readMuxNonEmptyString(discordData?.botUserId);
+  const rawMentions = Array.isArray(rawMessage?.mentions) ? rawMessage.mentions : [];
+  const rawMentionRoles = Array.isArray(rawMessage?.mention_roles) ? rawMessage.mention_roles : [];
+  const mentionEveryone = rawMessage?.mention_everyone === true;
+
+  // Check both the structured mentions array and the body text for Discord's
+  // <@ID>/<@!ID> syntax.  The array is the canonical source, but edge cases
+  // (webhook/forwarded messages, API inconsistencies) can leave it empty even
+  // when the body text contains the mention.
+  const mentionInArray = rawMentions.some(
+    (m: unknown) =>
+      asMuxRecord(m) != null && readMuxNonEmptyString(asMuxRecord(m)?.id) === botUserId,
+  );
+  const mentionInBody =
+    params.body.includes(`<@${botUserId}>`) || params.body.includes(`<@!${botUserId}>`);
+  const explicitlyMentioned = Boolean(botUserId && (mentionInArray || mentionInBody));
+  const hasAnyMention =
+    rawMentions.length > 0 || rawMentionRoles.length > 0 || mentionEveryone || mentionInBody;
+  const mentionRegexes = buildMentionRegexes(params.cfg);
+  const wasMentioned = matchesMentionWithExplicit({
+    text: params.body,
+    mentionRegexes,
+    explicit: {
+      hasAnyMention,
+      isExplicitlyMentioned: explicitlyMentioned,
+      canResolveExplicit: Boolean(botUserId),
+    },
+  });
+
   const requireMention = resolveDiscordShouldRequireMention({
     isGuildMessage: true,
     isThread: parentChannelId != null,
@@ -1029,9 +1063,9 @@ async function resolveDiscordMuxAccess(params: {
   const mentionGate = resolveMentionGatingWithBypass({
     isGroup: true,
     requireMention,
-    canDetectMention: true,
-    wasMentioned: params.wasMentioned,
-    hasAnyMention: params.wasMentioned,
+    canDetectMention: Boolean(botUserId),
+    wasMentioned,
+    hasAnyMention,
     allowTextCommands: true,
     hasControlCommand: hasControlCommandInMessage,
     commandAuthorized: commandGate.commandAuthorized,
@@ -1460,7 +1494,6 @@ export async function handleMuxInboundHttpRequest(
           channelData,
           body: inboundBody,
           chatType: String(ctx.ChatType ?? "direct"),
-          wasMentioned: payload.wasMentioned === true,
         });
         if (!applyMuxAccessToContext(ctx, discordAccess)) {
           return;


### PR DESCRIPTION
## Summary

- Moves Discord `wasMentioned` computation from mux-server to the gateway, keeping mux as a pure transport layer
- Mux-server now passes raw Discord data (`botUserId`, `rawMessage` with `mentions` array) in `channelData.discord`
- Gateway computes `wasMentioned` using the same `matchesMentionWithExplicit` function as the non-mux Discord adapter
- Adds body-text `<@BOT_ID>` fallback alongside the structured `mentions` array check
- Free upgrade: mux path now also matches configured name/emoji mention patterns via `buildMentionRegexes`

Fixes #335

## Test plan

- [x] All 8 Discord mux integration tests pass (7 existing + 1 new)
- [x] New test: "detects mention from body text when mentions array is empty" — sends guild message with `<@BOT_ID>` in body but empty `mentions` array, verifies gateway detects the mention and replies
- [x] TypeScript typecheck passes