### PR TITLE
fix(release): add ui:build to tgz release workflow

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Build Control UI
+        run: pnpm ui:build
+
       - name: Pack and upload release tarball
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.3.13-phala.13",
+  "version": "2026.3.13-phala.14",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",


### PR DESCRIPTION
## Summary
- Add `pnpm ui:build` step to the release tarball workflow so Control UI assets are included in the tgz
- Bump version to `2026.3.13-phala.14`

The gateway was showing "Control UI assets not found" because `pnpm build` does not build the Control UI — it requires a separate `pnpm ui:build` step which was missing from the release workflow.

## Test plan
- [ ] Tag triggers release workflow
- [ ] Release tgz includes `dist/control-ui/index.html`
- [ ] Gateway serves Control UI after install from new tgz

🤖 Generated with [Claude Code](https://claude.com/claude-code)