### PR TITLE
Fix WhatsApp mux routing for bare group ids

### DIFF
--- a/phala-deploy/integration-test/whatsapp.mux-roundtrip.e2e.test.ts
+++ b/phala-deploy/integration-test/whatsapp.mux-roundtrip.e2e.test.ts
@@ -155,4 +155,65 @@ describe("WhatsApp mux round trip", () => {
     },
     60_000,
   );
+
+  test.each(["session-first", "target-first"] as const)(
+    "round-trips a WhatsApp group when the mux session key uses a bare group id in %s mode",
+    async (resolutionMode) => {
+      const bareGroupId = "117901482786828";
+      const canonicalGroupJid = `${bareGroupId}@g.us`;
+      const senderE164 = "+15550002222";
+      const inboundText = `hello from bare whatsapp group ${resolutionMode}`;
+      const expectedReply = `WHATSAPP_GROUP_BARE_OK_${resolutionMode}`;
+
+      await withMuxOpenClawHarness(
+        {
+          channel: "whatsapp",
+          chatId: canonicalGroupJid,
+          claimedSessionKey: `agent:main:whatsapp:group:${bareGroupId}`,
+          pairingRouteKey: `whatsapp:default:chat:${canonicalGroupJid}`,
+          llmReplyText: expectedReply,
+          resolutionMode,
+          minimalGateway: false,
+        },
+        async (harness) => {
+          const whatsapp = harness.whatsapp;
+          expect(whatsapp).toBeDefined();
+          if (!whatsapp) {
+            throw new Error("whatsapp harness not available");
+          }
+
+          whatsapp.enqueueMessage({
+            id: "wa-group-bare-9001",
+            from: canonicalGroupJid,
+            conversationId: canonicalGroupJid,
+            to: "+15551230000",
+            accountId: "default",
+            body: inboundText,
+            chatType: "group",
+            chatId: canonicalGroupJid,
+            senderE164,
+            senderName: "Group Sender",
+            pushName: "Group Sender",
+            wasMentioned: true,
+            timestamp: Date.now(),
+          });
+
+          await harness.openai.waitForRequest(
+            (request) => request.lastUserText.includes(inboundText),
+            10_000,
+          );
+
+          const outbound = await whatsapp.waitForRequest(
+            (request) =>
+              request.kind === "sendMessage" &&
+              request.to === canonicalGroupJid &&
+              request.text === expectedReply,
+            20_000,
+          );
+          expect(outbound).toBeDefined();
+        },
+      );
+    },
+    60_000,
+  );
 });

--- a/src/channels/plugins/outbound/mux-routing.test.ts
+++ b/src/channels/plugins/outbound/mux-routing.test.ts
@@ -506,6 +506,61 @@ describe("mux outbound routing", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("canonicalizes bare whatsapp group ids before mux outbound send", async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = resolveFetchUrl(input);
+      if (url === "http://mux.local/v1/instances/register") {
+        return jsonResponse({
+          ok: true,
+          runtimeToken: RUNTIME_TOKEN,
+          expiresAtMs: Date.now() + 24 * 60 * 60 * 1000,
+        });
+      }
+      if (url === "http://mux.local/v1/mux/outbound/send") {
+        return jsonResponse({ messageId: "mx-wa-group-1" });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const cfg = {
+      ...gatewayMuxConfig(),
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: {
+              mux: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await whatsappOutbound.sendText!({
+      cfg,
+      to: "117901482786828",
+      text: "hello",
+      sessionKey: "agent:main:whatsapp:group:117901482786828",
+    });
+
+    const sendCall = fetchSpy.mock.calls.find(
+      ([callInput]) => resolveFetchUrl(callInput) === "http://mux.local/v1/mux/outbound/send",
+    );
+    expect(sendCall).toBeDefined();
+    const init = sendCall?.[1];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("expected mux outbound send call");
+    }
+    expect(parseJsonRequestBody(init)).toMatchObject({
+      channel: "whatsapp",
+      sessionKey: "agent:main:whatsapp:group:117901482786828",
+      to: "117901482786828@g.us",
+    });
+  });
+
   it("routes typing through mux when enabled", async () => {
     const fetchSpy = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
       const url = resolveFetchUrl(input);

--- a/src/channels/plugins/outbound/mux.ts
+++ b/src/channels/plugins/outbound/mux.ts
@@ -8,6 +8,7 @@ import {
   resolveDefaultMuxBusinessAccountId,
   resolveMuxBusinessAccountId,
 } from "../../../utils/mux-account.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../../whatsapp/normalize.js";
 
 type SupportedMuxChannel = "whatsapp" | "telegram" | "discord";
 
@@ -105,6 +106,47 @@ function normalizeBaseUrl(value?: string): string | undefined {
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stripWhatsAppPrefix(value: string): string {
+  let candidate = value.trim();
+  for (;;) {
+    const next = candidate.replace(/^whatsapp:/i, "").trim();
+    if (next === candidate) {
+      return candidate;
+    }
+    candidate = next;
+  }
+}
+
+function isWhatsAppGroupSessionKey(sessionKey: string): boolean {
+  return sessionKey.startsWith("wa:group:") || sessionKey.includes(":whatsapp:group:");
+}
+
+function canonicalizeMuxTarget(params: {
+  channel: SupportedMuxChannel;
+  to?: string;
+  sessionKey: string;
+}): string | undefined {
+  const rawTo = readString(params.to);
+  if (!rawTo || params.channel !== "whatsapp") {
+    return rawTo;
+  }
+
+  if (!isWhatsAppGroupSessionKey(params.sessionKey)) {
+    return rawTo;
+  }
+
+  const strippedTarget = stripWhatsAppPrefix(rawTo);
+  if (isWhatsAppGroupJid(strippedTarget)) {
+    return normalizeWhatsAppTarget(strippedTarget) ?? strippedTarget;
+  }
+
+  if (/^[0-9]+(?:-[0-9]+)*$/.test(strippedTarget)) {
+    return `${strippedTarget}@g.us`;
+  }
+
+  return rawTo;
 }
 
 function normalizeChannelMuxConfig(
@@ -539,12 +581,17 @@ export async function sendViaMux(params: MuxSendRequest): Promise<MuxSendRespons
   });
 
   const requestId = randomUUID();
+  const canonicalTo = canonicalizeMuxTarget({
+    channel: params.channel,
+    to: params.to,
+    sessionKey: resolved.sessionKey,
+  });
   const payload = {
     requestId,
     channel: params.channel,
     sessionKey: resolved.sessionKey,
     accountId,
-    to: params.to,
+    to: canonicalTo,
     text: params.text ?? "",
     mediaUrl: params.mediaUrl,
     mediaUrls: params.mediaUrls,

--- a/src/channels/plugins/outbound/mux.ts
+++ b/src/channels/plugins/outbound/mux.ts
@@ -109,14 +109,10 @@ function readString(value: unknown): string | undefined {
 }
 
 function stripWhatsAppPrefix(value: string): string {
-  let candidate = value.trim();
-  for (;;) {
-    const next = candidate.replace(/^whatsapp:/i, "").trim();
-    if (next === candidate) {
-      return candidate;
-    }
-    candidate = next;
-  }
+  return value
+    .trim()
+    .replace(/^whatsapp:/i, "")
+    .trim();
 }
 
 function isWhatsAppGroupSessionKey(sessionKey: string): boolean {


### PR DESCRIPTION
## Summary
- canonicalize WhatsApp group targets in OpenClaw before mux outbound sends so mux stays transport-only
- add a unit regression for bare group ids in the mux outbound path
- add an integration test that covers a group reply when the mux session key carries a bare group id but the paired route is the canonical `@g.us` JID

## Verification
- `pnpm test -- src/channels/plugins/outbound/mux-routing.test.ts`
- `pnpm exec vitest run --config phala-deploy/integration-test/vitest.config.ts phala-deploy/integration-test/whatsapp.mux-roundtrip.e2e.test.ts`
- `pnpm build`

Closes #349
