### PR TITLE
[codex] feat(mentat-bridge): add discord history and wiki link tools

### DIFF
--- a/extensions/mentat-bridge/client.ts
+++ b/extensions/mentat-bridge/client.ts
@@ -16,6 +16,7 @@ import type {
   SearchResponse,
   SkillResponse,
   StatsResponse,
+  WikiResolveResponse,
 } from "./types.js";
 
 type Logger = {
@@ -229,6 +230,34 @@ export class MentatClient {
     return res?.removed_doc_ids ?? [];
   }
 
+  // ── Wiki ─────────────────────────────────────────────────────────
+
+  /** Resolve a wiki URL (or short page id with optional fragment) to doc_id + section. */
+  async resolveWikiUrl(url: string): Promise<WikiResolveResponse | null> {
+    return this.request<WikiResolveResponse>("GET", `/wiki/resolve?url=${encodeURIComponent(url)}`);
+  }
+
+  /**
+   * Fetch rendered wiki content for agent-owned pages like /wiki/topics/<slug>
+   * or /wiki/ when resolveWikiUrl is not applicable.
+   */
+  async fetchWikiText(url: string): Promise<string | null> {
+    if (!this.healthy) return null;
+    const target = this.normalizeWikiUrl(url);
+    if (!target) return null;
+
+    try {
+      const res = await fetch(target, {
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!res.ok) return null;
+      const html = await res.text();
+      return htmlToText(html);
+    } catch {
+      return null;
+    }
+  }
+
   // ── Stats ────────────────────────────────────────────────────────
 
   async getStats(): Promise<StatsResponse | null> {
@@ -259,4 +288,41 @@ export class MentatClient {
       return null;
     }
   }
+
+  private normalizeWikiUrl(url: string): string | null {
+    const trimmed = url.trim();
+    if (!trimmed) return null;
+
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+    if (trimmed.startsWith("/")) {
+      return `${this.baseUrl}${trimmed}`;
+    }
+
+    if (trimmed.startsWith("wiki/")) {
+      return `${this.baseUrl}/${trimmed}`;
+    }
+
+    return `${this.baseUrl}/wiki/pages/${encodeURIComponent(trimmed)}`;
+  }
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<\/(p|div|section|article|nav|li|h1|h2|h3|h4|h5|h6|pre|blockquote|tr)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/\s+([.,;:!?])/g, "$1")
+    .trim();
 }

--- a/extensions/mentat-bridge/config.ts
+++ b/extensions/mentat-bridge/config.ts
@@ -7,6 +7,9 @@ export type MentatBridgeConfig = {
   compressResults: boolean;
   compressThresholdTokens: number;
   chatHistory: boolean;
+  discordHistory: boolean;
+  discrawlDbPath: string;
+  discordHistoryExportDir: string;
 };
 
 const DEFAULTS: MentatBridgeConfig = {
@@ -18,6 +21,9 @@ const DEFAULTS: MentatBridgeConfig = {
   compressResults: true,
   compressThresholdTokens: 2000,
   chatHistory: true,
+  discordHistory: false,
+  discrawlDbPath: "~/.discrawl/discrawl.db",
+  discordHistoryExportDir: "~/.openclaw/mentat/discord-history",
 };
 
 const ALLOWED_KEYS = [
@@ -29,6 +35,9 @@ const ALLOWED_KEYS = [
   "compressResults",
   "compressThresholdTokens",
   "chatHistory",
+  "discordHistory",
+  "discrawlDbPath",
+  "discordHistoryExportDir",
 ] as const;
 
 function assertAllowedKeys(
@@ -52,17 +61,40 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+function expandHome(value: string): string {
+  if (value === "~") return process.env.HOME ?? value;
+  if (value.startsWith("~/")) {
+    const home = process.env.HOME;
+    return home ? `${home}/${value.slice(2)}` : value;
+  }
+  return value;
+}
+
 export const mentatBridgeConfigSchema = {
   parse(value: unknown): MentatBridgeConfig {
+    const defaultDiscrawlDbPath = expandHome(DEFAULTS.discrawlDbPath);
+    const defaultDiscordHistoryExportDir = expandHome(DEFAULTS.discordHistoryExportDir);
     if (!value || typeof value !== "object" || Array.isArray(value)) {
       // No config provided — use all defaults
-      return { ...DEFAULTS };
+      return {
+        ...DEFAULTS,
+        discrawlDbPath: defaultDiscrawlDbPath,
+        discordHistoryExportDir: defaultDiscordHistoryExportDir,
+      };
     }
     const cfg = value as Record<string, unknown>;
     assertAllowedKeys(cfg, ALLOWED_KEYS, "mentat-bridge config");
 
     const mentatUrl =
       typeof cfg.mentatUrl === "string" ? resolveEnvVars(cfg.mentatUrl) : DEFAULTS.mentatUrl;
+    const discrawlDbPath =
+      typeof cfg.discrawlDbPath === "string"
+        ? expandHome(resolveEnvVars(cfg.discrawlDbPath))
+        : defaultDiscrawlDbPath;
+    const discordHistoryExportDir =
+      typeof cfg.discordHistoryExportDir === "string"
+        ? expandHome(resolveEnvVars(cfg.discordHistoryExportDir))
+        : defaultDiscordHistoryExportDir;
 
     const compressThresholdTokens =
       typeof cfg.compressThresholdTokens === "number"
@@ -82,6 +114,10 @@ export const mentatBridgeConfigSchema = {
         typeof cfg.compressResults === "boolean" ? cfg.compressResults : DEFAULTS.compressResults,
       compressThresholdTokens,
       chatHistory: typeof cfg.chatHistory === "boolean" ? cfg.chatHistory : DEFAULTS.chatHistory,
+      discordHistory:
+        typeof cfg.discordHistory === "boolean" ? cfg.discordHistory : DEFAULTS.discordHistory,
+      discrawlDbPath,
+      discordHistoryExportDir,
     };
   },
   uiHints: {
@@ -114,6 +150,22 @@ export const mentatBridgeConfigSchema = {
       label: "Compression Threshold (tokens)",
       placeholder: "2000",
       help: "Files smaller than this are kept as-is",
+      advanced: true,
+    },
+    discordHistory: {
+      label: "Enable Discord History",
+      help: "Index discrawl's mirrored Discord archive into a Mentat collection for agent search",
+    },
+    discrawlDbPath: {
+      label: "discrawl DB Path",
+      placeholder: "~/.discrawl/discrawl.db",
+      help: "Path to the discrawl SQLite database to mirror into Mentat",
+      advanced: true,
+    },
+    discordHistoryExportDir: {
+      label: "Discord Export Dir",
+      placeholder: "~/.openclaw/mentat/discord-history",
+      help: "Directory where mentat-bridge writes append-only JSONL files for Mentat watcher",
       advanced: true,
     },
   },

--- a/extensions/mentat-bridge/discord-history.ts
+++ b/extensions/mentat-bridge/discord-history.ts
@@ -1,0 +1,451 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile, appendFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { requireNodeSqlite } from "../../src/memory/sqlite.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  debug?: (msg: string) => void;
+};
+
+type Checkpoint = {
+  lastCreatedAt: string;
+  lastMessageId: string;
+};
+
+type ChannelCheckpointMap = Record<string, Checkpoint>;
+
+type RawMessageRow = {
+  message_id: string;
+  guild_id: string;
+  channel_id: string;
+  channel_name: string;
+  channel_kind: string;
+  author_id: string;
+  author_name: string;
+  content: string;
+  created_at: string;
+  reply_to_message_id: string;
+  has_attachments: number;
+  pinned: number;
+};
+
+type ExportRecord = {
+  type: "message";
+  message_id: string;
+  guild_id: string;
+  channel_id: string;
+  channel_name: string;
+  channel_kind: string;
+  author_id: string;
+  author_name: string;
+  created_at: string;
+  content: string;
+  reply_to_message_id?: string;
+  has_attachments: boolean;
+  pinned: boolean;
+  search_text: string;
+};
+
+type ReadHistoryParams = {
+  channel?: string;
+  author?: string;
+  last_n?: number;
+  since?: string;
+  hours?: number;
+  days?: number;
+};
+
+export type ReadHistoryMessage = {
+  messageId: string;
+  guildId: string;
+  channelId: string;
+  channelName: string;
+  authorId: string;
+  authorName: string;
+  content: string;
+  createdAt: string;
+  replyToMessageId?: string;
+  hasAttachments: boolean;
+  pinned: boolean;
+};
+
+export type ReadHistoryResult = {
+  available: boolean;
+  error?: string;
+  messages?: ReadHistoryMessage[];
+  total?: number;
+};
+
+const DEFAULT_SYNC_INTERVAL_MS = 30_000;
+const CHECKPOINT_FILE = "_checkpoints.json";
+const MAX_READ_MESSAGES = 200;
+
+function sanitizeSegment(value: string): string {
+  const normalized = value
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+  return normalized || "unknown";
+}
+
+function normalizeChannelFilter(raw?: string): string {
+  return raw?.trim().replace(/^#/, "") ?? "";
+}
+
+function buildSearchText(row: RawMessageRow): string {
+  const prefix = `[${row.created_at}] #${row.channel_name || row.channel_id} ${row.author_name || row.author_id || "unknown"}`;
+  const flags: string[] = [];
+  if (row.has_attachments) flags.push("attachments");
+  if (row.pinned) flags.push("pinned");
+  const suffix = flags.length > 0 ? ` (${flags.join(", ")})` : "";
+  return `${prefix}${suffix}: ${row.content}`.trim();
+}
+
+function compareCursor(aCreatedAt: string, aMessageId: string, b?: Checkpoint): number {
+  if (!b) return 1;
+  if (aCreatedAt > b.lastCreatedAt) return 1;
+  if (aCreatedAt < b.lastCreatedAt) return -1;
+  if (aMessageId > b.lastMessageId) return 1;
+  if (aMessageId < b.lastMessageId) return -1;
+  return 0;
+}
+
+export class DiscrawlDiscordHistoryBridge {
+  readonly collectionName = "discord_history";
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private checkpoints: ChannelCheckpointMap | null = null;
+  private syncing = false;
+
+  constructor(
+    private readonly opts: {
+      enabled: boolean;
+      dbPath: string;
+      exportDir: string;
+      syncIntervalMs?: number;
+    },
+    private readonly logger: Logger,
+  ) {}
+
+  get exportDir(): string {
+    return this.opts.exportDir;
+  }
+
+  isAvailable(): boolean {
+    return this.opts.enabled && existsSync(this.opts.dbPath);
+  }
+
+  describeAvailability(): string {
+    if (!this.opts.enabled) {
+      return "Discord history is disabled in mentat-bridge config.";
+    }
+    if (!existsSync(this.opts.dbPath)) {
+      return `discrawl database not found at ${this.opts.dbPath}`;
+    }
+    return "ok";
+  }
+
+  async start(): Promise<void> {
+    if (!this.opts.enabled) return;
+    await mkdir(this.opts.exportDir, { recursive: true });
+    await this.syncNow();
+    const intervalMs = this.opts.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
+    this.timer = setInterval(() => {
+      this.syncNow().catch((err) => {
+        this.logger.warn(`mentat-bridge: discord history sync failed: ${String(err)}`);
+      });
+    }, intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async syncNow(): Promise<{ channels: number; messages: number }> {
+    if (!this.isAvailable()) {
+      return { channels: 0, messages: 0 };
+    }
+    if (this.syncing) {
+      return { channels: 0, messages: 0 };
+    }
+    this.syncing = true;
+    try {
+      const db = this.openDb();
+      try {
+        const rows = db
+          .prepare(
+            `
+              select
+                m.id as message_id,
+                m.guild_id as guild_id,
+                m.channel_id as channel_id,
+                coalesce(c.name, '') as channel_name,
+                coalesce(c.kind, '') as channel_kind,
+                coalesce(m.author_id, '') as author_id,
+                coalesce(
+                  nullif(mem.display_name, ''),
+                  nullif(mem.nick, ''),
+                  nullif(mem.global_name, ''),
+                  nullif(mem.username, ''),
+                  nullif(json_extract(m.raw_json, '$.author.global_name'), ''),
+                  nullif(json_extract(m.raw_json, '$.author.username'), ''),
+                  ''
+                ) as author_name,
+                case
+                  when trim(coalesce(m.content, '')) <> '' then m.content
+                  else m.normalized_content
+                end as content,
+                m.created_at as created_at,
+                coalesce(m.reply_to_message_id, '') as reply_to_message_id,
+                m.has_attachments as has_attachments,
+                m.pinned as pinned
+              from messages m
+              left join channels c on c.id = m.channel_id
+              left join members mem on mem.guild_id = m.guild_id and mem.user_id = m.author_id
+              where trim(coalesce(m.normalized_content, '')) <> ''
+              order by m.channel_id asc, m.created_at asc, m.id asc
+            `,
+          )
+          .all() as RawMessageRow[];
+
+        const checkpoints = await this.loadCheckpoints();
+        const appendMap = new Map<string, string[]>();
+        let exportedMessages = 0;
+
+        for (const row of rows) {
+          const current = checkpoints[row.channel_id];
+          if (compareCursor(row.created_at, row.message_id, current) <= 0) {
+            continue;
+          }
+          const record: ExportRecord = {
+            type: "message",
+            message_id: row.message_id,
+            guild_id: row.guild_id,
+            channel_id: row.channel_id,
+            channel_name: row.channel_name,
+            channel_kind: row.channel_kind,
+            author_id: row.author_id,
+            author_name: row.author_name,
+            created_at: row.created_at,
+            content: row.content,
+            ...(row.reply_to_message_id ? { reply_to_message_id: row.reply_to_message_id } : {}),
+            has_attachments: row.has_attachments === 1,
+            pinned: row.pinned === 1,
+            search_text: buildSearchText(row),
+          };
+          const filePath = this.channelFilePath(row.guild_id, row.channel_id, row.channel_name);
+          const bucket = appendMap.get(filePath) ?? [];
+          bucket.push(JSON.stringify(record));
+          appendMap.set(filePath, bucket);
+          checkpoints[row.channel_id] = {
+            lastCreatedAt: row.created_at,
+            lastMessageId: row.message_id,
+          };
+          exportedMessages += 1;
+        }
+
+        for (const [filePath, lines] of appendMap) {
+          await mkdir(dirname(filePath), { recursive: true });
+          await appendFile(filePath, `${lines.join("\n")}\n`, "utf8");
+        }
+
+        await this.saveCheckpoints(checkpoints);
+        const channelCount = db
+          .prepare(`select count(*) as count from channels where kind <> 'category'`)
+          .get() as { count: number };
+
+        if (exportedMessages > 0) {
+          this.logger.info(
+            `mentat-bridge: exported ${exportedMessages} Discord messages into ${appendMap.size} file(s)`,
+          );
+        }
+
+        return { channels: channelCount.count, messages: exportedMessages };
+      } finally {
+        db.close();
+      }
+    } finally {
+      this.syncing = false;
+    }
+  }
+
+  async readHistory(params: ReadHistoryParams): Promise<ReadHistoryResult> {
+    if (!this.isAvailable()) {
+      return {
+        available: false,
+        error: this.describeAvailability(),
+      };
+    }
+
+    const db = this.openDb();
+    try {
+      const conditions = ["trim(coalesce(m.normalized_content, '')) <> ''"];
+      const values: Array<string | number> = [];
+
+      const channel = normalizeChannelFilter(params.channel);
+      if (channel) {
+        conditions.push("(m.channel_id = ? or c.name = ? or c.name like ?)");
+        values.push(channel, channel, `%${channel}%`);
+      }
+
+      const author = params.author?.trim();
+      if (author) {
+        conditions.push(
+          `(m.author_id = ? or coalesce(mem.username, '') = ? or coalesce(mem.display_name, '') = ? or coalesce(mem.username, '') like ? or coalesce(mem.display_name, '') like ?)`,
+        );
+        values.push(author, author, author, `%${author}%`, `%${author}%`);
+      }
+
+      let since = params.since?.trim() ? new Date(params.since) : null;
+      if (!since || Number.isNaN(since.getTime())) {
+        since = null;
+      }
+      if (params.hours && params.hours > 0) {
+        since = new Date(Date.now() - params.hours * 60 * 60 * 1000);
+      } else if (params.days && params.days > 0) {
+        since = new Date(Date.now() - params.days * 24 * 60 * 60 * 1000);
+      }
+      if (since) {
+        conditions.push("m.created_at >= ?");
+        values.push(since.toISOString());
+      }
+
+      const limit = Math.min(Math.max(params.last_n ?? 50, 1), MAX_READ_MESSAGES);
+      values.push(limit, limit);
+
+      const rows = db
+        .prepare(
+          `
+            select * from (
+              select
+                m.id as message_id,
+                m.guild_id as guild_id,
+                m.channel_id as channel_id,
+                coalesce(c.name, '') as channel_name,
+                coalesce(m.author_id, '') as author_id,
+                coalesce(
+                  nullif(mem.display_name, ''),
+                  nullif(mem.nick, ''),
+                  nullif(mem.global_name, ''),
+                  nullif(mem.username, ''),
+                  nullif(json_extract(m.raw_json, '$.author.global_name'), ''),
+                  nullif(json_extract(m.raw_json, '$.author.username'), ''),
+                  ''
+                ) as author_name,
+                case
+                  when trim(coalesce(m.content, '')) <> '' then m.content
+                  else m.normalized_content
+                end as content,
+                m.created_at as created_at,
+                coalesce(m.reply_to_message_id, '') as reply_to_message_id,
+                m.has_attachments as has_attachments,
+                m.pinned as pinned
+              from messages m
+              left join channels c on c.id = m.channel_id
+              left join members mem on mem.guild_id = m.guild_id and mem.user_id = m.author_id
+              where ${conditions.join(" and ")}
+              order by m.created_at desc, m.id desc
+              limit ?
+            ) recent
+            order by created_at asc, message_id asc
+            limit ?
+          `,
+        )
+        .all(...values) as Array<
+        RawMessageRow & {
+          channel_name: string;
+        }
+      >;
+
+      return {
+        available: true,
+        total: rows.length,
+        messages: rows.map((row) => ({
+          messageId: row.message_id,
+          guildId: row.guild_id,
+          channelId: row.channel_id,
+          channelName: row.channel_name,
+          authorId: row.author_id,
+          authorName: row.author_name,
+          content: row.content,
+          createdAt: row.created_at,
+          ...(row.reply_to_message_id ? { replyToMessageId: row.reply_to_message_id } : {}),
+          hasAttachments: row.has_attachments === 1,
+          pinned: row.pinned === 1,
+        })),
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  private openDb(): import("node:sqlite").DatabaseSync {
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(this.opts.dbPath, { readOnly: true });
+    db.exec("PRAGMA busy_timeout = 1000");
+    return db;
+  }
+
+  private async loadCheckpoints(): Promise<ChannelCheckpointMap> {
+    if (this.checkpoints) {
+      return this.checkpoints;
+    }
+    const statePath = join(this.opts.exportDir, CHECKPOINT_FILE);
+    try {
+      const raw = await readFile(statePath, "utf8");
+      this.checkpoints = JSON.parse(raw) as ChannelCheckpointMap;
+    } catch {
+      this.checkpoints = {};
+    }
+    return this.checkpoints;
+  }
+
+  private async saveCheckpoints(checkpoints: ChannelCheckpointMap): Promise<void> {
+    this.checkpoints = checkpoints;
+    const target = join(this.opts.exportDir, CHECKPOINT_FILE);
+    const tmp = `${target}.tmp`;
+    await writeFile(tmp, JSON.stringify(checkpoints, null, 2), "utf8");
+    await rename(tmp, target);
+  }
+
+  private channelFilePath(guildId: string, channelId: string, channelName: string): string {
+    const filename = `channel-${channelId}-${sanitizeSegment(channelName)}.jsonl`;
+    return join(this.opts.exportDir, `guild-${guildId}`, filename);
+  }
+}
+
+export function buildDiscordHistoryCollectionConfig(exportDir: string) {
+  return {
+    metadata: {
+      type: "system",
+      description: "Discord guild history mirrored by discrawl",
+      watch_mode: "append",
+      initial_scan_recent_days: 365,
+      watch_probe_config: {
+        filters: [{ field: "type", op: "eq", value: "message" }],
+        text_fields: ["search_text"],
+        group_size: 6,
+        group_separator: "\n\n",
+        timestamp_field: "created_at",
+      },
+    },
+    watch_paths: [exportDir],
+    watch_ignore: [CHECKPOINT_FILE, "*.tmp"],
+  };
+}
+
+export function summarizeDiscordMessages(messages: ReadHistoryMessage[]): string {
+  return messages
+    .map((message) => {
+      const channelPrefix = `#${message.channelName || message.channelId}`;
+      return `[${channelPrefix}] ${message.authorName || message.authorId} ${message.createdAt}\n${message.content}`;
+    })
+    .join("\n\n");
+}

--- a/extensions/mentat-bridge/index.test.ts
+++ b/extensions/mentat-bridge/index.test.ts
@@ -28,6 +28,10 @@ describe("config", () => {
     expect(cfg.autoCapture).toBe(false);
     expect(cfg.compressResults).toBe(true);
     expect(cfg.compressThresholdTokens).toBe(2000);
+    expect(cfg.chatHistory).toBe(true);
+    expect(cfg.discordHistory).toBe(false);
+    expect(cfg.discrawlDbPath).toContain(".discrawl/discrawl.db");
+    expect(cfg.discordHistoryExportDir).toContain(".openclaw/mentat/discord-history");
   });
 
   test("returns defaults for empty object", async () => {
@@ -44,11 +48,17 @@ describe("config", () => {
       enabled: false,
       autoCapture: true,
       compressThresholdTokens: 5000,
+      discordHistory: true,
+      discrawlDbPath: "/tmp/discrawl.db",
+      discordHistoryExportDir: "/tmp/discord-export",
     });
     expect(cfg.mentatUrl).toBe("http://mentat:9000");
     expect(cfg.enabled).toBe(false);
     expect(cfg.autoCapture).toBe(true);
     expect(cfg.compressThresholdTokens).toBe(5000);
+    expect(cfg.discordHistory).toBe(true);
+    expect(cfg.discrawlDbPath).toBe("/tmp/discrawl.db");
+    expect(cfg.discordHistoryExportDir).toBe("/tmp/discord-export");
   });
 
   test("resolves env vars in mentatUrl", async () => {
@@ -376,7 +386,7 @@ describe("prompt", () => {
     const { fetchSkillPrompt } = await import("./prompt.js");
     const mockClient = { getSkillPrompt: vi.fn(async () => null) };
     const result = await fetchSkillPrompt(mockClient as never);
-    expect(result).toContain("Memory System (Mentat)");
+    expect(result).toContain("Document Intelligence System (Mentat)");
     expect(result).toContain("search_memory");
   });
 
@@ -561,6 +571,44 @@ describe("MentatClient", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2); // health + skill (second call used cache)
   });
 
+  test("resolveWikiUrl sends GET to /wiki/resolve", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        doc_id: "doc-123",
+        section_path: "Setup",
+        filename: "guide.md",
+      }),
+    });
+    const { client } = await createClient();
+    await client.checkHealth();
+
+    const res = await client.resolveWikiUrl("/wiki/pages/abc12345#setup");
+    expect(res).toEqual({
+      doc_id: "doc-123",
+      section_path: "Setup",
+      filename: "guide.md",
+    });
+    const [url, opts] = fetchSpy.mock.calls[1];
+    expect(url).toBe("http://localhost:7832/wiki/resolve?url=%2Fwiki%2Fpages%2Fabc12345%23setup");
+    expect(opts.method).toBe("GET");
+  });
+
+  test("fetchWikiText normalizes relative wiki paths and strips HTML", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({
+      ok: true,
+      text: async () =>
+        "<html><body><nav>Nav</nav><h1>Topic</h1><p>Hello <strong>wiki</strong>.</p></body></html>",
+    });
+    const { client } = await createClient();
+    await client.checkHealth();
+
+    const text = await client.fetchWikiText("/wiki/topics/authentication");
+    expect(text).toContain("Topic");
+    expect(text).toContain("Hello wiki.");
+    expect(fetchSpy.mock.calls[1]?.[0]).toBe("http://localhost:7832/wiki/topics/authentication");
+  });
+
   test("listCollections handles wrapped { collections: [...] } response", async () => {
     fetchSpy
       .mockResolvedValueOnce({ ok: true }) // health
@@ -633,11 +681,14 @@ describe("MentatClient", () => {
 describe("tools", () => {
   function createMockClient(healthy = true) {
     return {
+      ensureStarted: vi.fn(async () => {}),
       isHealthy: vi.fn(() => healthy),
       search: vi.fn(),
       searchGrouped: vi.fn(),
       getDocMeta: vi.fn(),
       readSegment: vi.fn(),
+      resolveWikiUrl: vi.fn(),
+      fetchWikiText: vi.fn(),
       indexFile: vi.fn(),
       indexContent: vi.fn(),
       getStatus: vi.fn(),
@@ -677,6 +728,9 @@ describe("tools", () => {
       compressResults: true,
       compressThresholdTokens: 2000,
       chatHistory: true,
+      discordHistory: false,
+      discrawlDbPath: "/tmp/discrawl.db",
+      discordHistoryExportDir: "/tmp/discord-export",
     };
   }
 
@@ -696,10 +750,10 @@ describe("tools", () => {
     );
   }
 
-  test("registers 9 tools", async () => {
+  test("registers 12 tools", async () => {
     const { api, tools } = createMockApi();
     await callRegisterTools(api, createMockClient());
-    expect(tools).toHaveLength(9);
+    expect(tools).toHaveLength(12);
     const names = tools.map((t) => t.opts.name);
     expect(names).toContain("search_memory");
     expect(names).toContain("memory_store");
@@ -708,6 +762,9 @@ describe("tools", () => {
     expect(names).toContain("read_segment");
     expect(names).toContain("index_file");
     expect(names).toContain("memory_status");
+    expect(names).toContain("search_discord_history");
+    expect(names).toContain("read_discord_history");
+    expect(names).toContain("read_wiki_link");
   });
 
   test("all tools return unhealthyResult when server is down", async () => {
@@ -723,6 +780,7 @@ describe("tools", () => {
       "read_segment",
       "index_file",
       "memory_status",
+      "read_wiki_link",
     ]) {
       const result = (await getTool(name).execute("call-1", {
         query: "test",
@@ -730,6 +788,7 @@ describe("tools", () => {
         text: "t",
         section_path: "s",
         path: "/f",
+        url: "/wiki/pages/abc12345#setup",
       })) as { details: { error: string } };
       expect(result.details.error).toBe("mentat_unavailable");
     }
@@ -1005,6 +1064,60 @@ describe("tools", () => {
     expect(result.content[0].text).toContain("50%");
     expect(result.content[0].text).toContain("processing");
   });
+
+  test("read_wiki_link resolves a section and reads it via read_segment", async () => {
+    const client = createMockClient();
+    client.resolveWikiUrl.mockResolvedValue({
+      doc_id: "d1",
+      section_path: "Setup",
+      filename: "guide.md",
+    });
+    client.readSegment.mockResolvedValue({
+      doc_id: "d1",
+      filename: "guide.md",
+      section_path: "Setup",
+      chunks: [{ chunk_id: "c1", section: "Setup", content: "Run npm install" }],
+      toc_context: [{ level: 2, title: "Setup" }],
+      token_estimate: 12,
+      expanded: false,
+    });
+    const { api, getTool } = createMockApi();
+    await callRegisterTools(api, client);
+
+    const result = (await getTool("read_wiki_link").execute("c1", {
+      url: "/wiki/pages/abc12345#setup",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { resolved: { doc_id: string } };
+    };
+
+    expect(client.resolveWikiUrl).toHaveBeenCalledWith("/wiki/pages/abc12345#setup");
+    expect(client.readSegment).toHaveBeenCalledWith({
+      doc_id: "d1",
+      section_path: "Setup",
+    });
+    expect(result.content[0].text).toContain("Run npm install");
+    expect(result.details.resolved.doc_id).toBe("d1");
+  });
+
+  test("read_wiki_link falls back to rendered wiki content for topic pages", async () => {
+    const client = createMockClient();
+    client.resolveWikiUrl.mockResolvedValue(null);
+    client.fetchWikiText.mockResolvedValue("Authentication\n\nVerified: 10/12");
+    const { api, getTool } = createMockApi();
+    await callRegisterTools(api, client);
+
+    const result = (await getTool("read_wiki_link").execute("c1", {
+      url: "/wiki/topics/authentication",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { mode: string; url: string };
+    };
+
+    expect(client.fetchWikiText).toHaveBeenCalledWith("/wiki/topics/authentication");
+    expect(result.content[0].text).toContain("Authentication");
+    expect(result.details.mode).toBe("wiki_html_fallback");
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1025,6 +1138,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(async () => {}),
         isHealthy: vi.fn(() => true),
         indexFileAsync: vi.fn(),
         getDocMeta: vi.fn(async () => ({ doc_id: "d1", filename: "test.ts" })),
@@ -1099,6 +1213,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(async () => {}),
         isHealthy: vi.fn(() => false),
         indexFileAsync: vi.fn(),
       };
@@ -1121,6 +1236,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(async () => {}),
         isHealthy: vi.fn(() => true),
         indexFileAsync: vi.fn(),
       };
@@ -1625,6 +1741,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(async () => {}),
         isHealthy: vi.fn(() => true),
         indexContent: vi.fn(async () => ({ doc_id: "c1", filename: "auto.md", status: "ok" })),
       };
@@ -1663,6 +1780,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), warn: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(async () => {}),
         isHealthy: vi.fn(() => true),
         indexContent: vi.fn(async () => ({ doc_id: "c1", filename: "auto.md", status: "ok" })),
       };
@@ -1697,7 +1815,11 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => false), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(async () => {}),
+        isHealthy: vi.fn(() => false),
+        indexContent: vi.fn(),
+      };
 
       registerAgentEndHook(api, client as never);
 
@@ -1718,7 +1840,11 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => true), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(async () => {}),
+        isHealthy: vi.fn(() => true),
+        indexContent: vi.fn(),
+      };
 
       registerAgentEndHook(api, client as never);
 
@@ -1739,7 +1865,11 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => true), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(async () => {}),
+        isHealthy: vi.fn(() => true),
+        indexContent: vi.fn(),
+      };
 
       registerAgentEndHook(api, client as never);
 
@@ -2122,6 +2252,9 @@ describe("read_chat_history tool", () => {
         compressResults: true,
         compressThresholdTokens: 2000,
         chatHistory: true,
+        discordHistory: false,
+        discrawlDbPath: "/tmp/discrawl.db",
+        discordHistoryExportDir: "/tmp/discord-export",
       },
       new ActiveSessionTracker(),
       tmpIndexed,
@@ -2170,6 +2303,9 @@ describe("read_chat_history tool", () => {
         compressResults: true,
         compressThresholdTokens: 2000,
         chatHistory: true,
+        discordHistory: false,
+        discrawlDbPath: "/tmp/discrawl.db",
+        discordHistoryExportDir: "/tmp/discord-export",
       },
       new ActiveSessionTracker(),
       "/tmp/nonexistent-indexed-dir",
@@ -2186,6 +2322,250 @@ describe("read_chat_history tool", () => {
 
     expect(result.details.error).toBe("not_found");
     expect(result.content[0].text).toContain("not found");
+  });
+});
+
+describe("discrawl discord history bridge", () => {
+  test("exports SQLite messages into append-only JSONL and can read them back", async () => {
+    const { mkdirSync, rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { requireNodeSqlite } = await import("../../src/memory/sqlite.js");
+    const { DiscrawlDiscordHistoryBridge } = await import("./discord-history.js");
+
+    const root = join("/tmp", `mentat-discrawl-${Date.now()}`);
+    const dbPath = join(root, "discrawl.db");
+    const exportDir = join(root, "export");
+    mkdirSync(root, { recursive: true });
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      create table channels (
+        id text primary key,
+        guild_id text not null,
+        parent_id text,
+        kind text not null,
+        name text not null,
+        topic text,
+        position integer,
+        is_nsfw integer not null default 0,
+        is_archived integer not null default 0,
+        is_locked integer not null default 0,
+        is_private_thread integer not null default 0,
+        thread_parent_id text,
+        archive_timestamp text,
+        raw_json text,
+        updated_at text
+      );
+      create table members (
+        guild_id text not null,
+        user_id text not null,
+        username text not null,
+        global_name text,
+        display_name text,
+        nick text,
+        discriminator text,
+        avatar text,
+        bot integer not null default 0,
+        joined_at text,
+        role_ids_json text,
+        raw_json text,
+        updated_at text,
+        primary key (guild_id, user_id)
+      );
+      create table messages (
+        id text primary key,
+        guild_id text not null,
+        channel_id text not null,
+        author_id text,
+        message_type integer not null default 0,
+        created_at text not null,
+        edited_at text,
+        deleted_at text,
+        content text not null default '',
+        normalized_content text not null default '',
+        reply_to_message_id text,
+        pinned integer not null default 0,
+        has_attachments integer not null default 0,
+        raw_json text not null default '{}',
+        updated_at text
+      );
+    `);
+    db.prepare(
+      "insert into channels (id, guild_id, kind, name, raw_json, updated_at) values (?, ?, ?, ?, '{}', ?)",
+    ).run("c1", "g1", "text", "general", "2026-04-07T00:00:00Z");
+    db.prepare(
+      "insert into members (guild_id, user_id, username, display_name, role_ids_json, raw_json, updated_at) values (?, ?, ?, ?, '[]', '{}', ?)",
+    ).run("g1", "u1", "alice", "Alice", "2026-04-07T00:00:00Z");
+    db.prepare(
+      "insert into messages (id, guild_id, channel_id, author_id, created_at, content, normalized_content, raw_json, updated_at) values (?, ?, ?, ?, ?, ?, ?, '{}', ?)",
+    ).run(
+      "m1",
+      "g1",
+      "c1",
+      "u1",
+      "2026-04-07T01:00:00Z",
+      "Need to ship the Discord bridge",
+      "Need to ship the Discord bridge",
+      "2026-04-07T01:00:00Z",
+    );
+    db.close();
+
+    const bridge = new DiscrawlDiscordHistoryBridge(
+      {
+        enabled: true,
+        dbPath,
+        exportDir,
+      },
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    );
+
+    const sync = await bridge.syncNow();
+    expect(sync.messages).toBe(1);
+
+    const exported = await import("node:fs/promises").then((fs) =>
+      fs.readFile(join(exportDir, "guild-g1", "channel-c1-general.jsonl"), "utf8"),
+    );
+    expect(exported).toContain("Need to ship the Discord bridge");
+    expect(exported).toContain('"channel_name":"general"');
+
+    const read = await bridge.readHistory({ channel: "general", last_n: 10 });
+    expect(read.available).toBe(true);
+    expect(read.messages).toHaveLength(1);
+    expect(read.messages?.[0].authorName).toBe("Alice");
+    expect(read.messages?.[0].content).toContain("Discord bridge");
+
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("discord history tools", () => {
+  test("search_discord_history queries mentat discord_history collection", async () => {
+    const { registerMentatTools } = await import("./tools.js");
+    const { ActiveSessionTracker } = await import("./session-state.js");
+
+    const tools: { tool: unknown; opts: { name: string } }[] = [];
+    const api = {
+      registerTool: (tool: unknown, opts: unknown) => {
+        tools.push({ tool: tool as never, opts: opts as { name: string } });
+      },
+      logger: { info: vi.fn(), warn: vi.fn() },
+    };
+    const client = {
+      isHealthy: vi.fn(() => true),
+      search: vi.fn(async () => [
+        {
+          doc_id: "doc-1",
+          filename: "guild-g1/channel-c1-general.jsonl@0",
+          content: "[2026-04-07T01:00:00Z] #general Alice: Need to ship the Discord bridge",
+          score: 0.12,
+        },
+      ]),
+    };
+    const discordHistory = {
+      collectionName: "discord_history",
+      isAvailable: () => true,
+      describeAvailability: () => "ok",
+    };
+
+    registerMentatTools(
+      api,
+      client as never,
+      {
+        mentatUrl: "http://localhost:7832",
+        enabled: true,
+        autoIndex: true,
+        autoRecall: true,
+        autoCapture: false,
+        compressResults: true,
+        compressThresholdTokens: 2000,
+        chatHistory: true,
+        discordHistory: true,
+        discrawlDbPath: "/tmp/discrawl.db",
+        discordHistoryExportDir: "/tmp/discord-export",
+      },
+      new ActiveSessionTracker(),
+      "/tmp/indexed",
+      discordHistory as never,
+    );
+
+    const tool = tools.find((item) => item.opts.name === "search_discord_history")!;
+    const result = await (
+      tool.tool as { execute: (id: string, params: unknown) => Promise<unknown> }
+    ).execute("call1", { query: "Discord bridge" });
+    expect(client.search).toHaveBeenCalledWith({
+      query: "Discord bridge",
+      top_k: 5,
+      collection: "discord_history",
+      hybrid: true,
+    });
+    expect((result as { content: Array<{ text: string }> }).content[0].text).toContain("#general");
+  });
+
+  test("read_discord_history returns exact messages from the bridge", async () => {
+    const { registerMentatTools } = await import("./tools.js");
+    const { ActiveSessionTracker } = await import("./session-state.js");
+
+    const tools: { tool: unknown; opts: { name: string } }[] = [];
+    const api = {
+      registerTool: (tool: unknown, opts: unknown) => {
+        tools.push({ tool: tool as never, opts: opts as { name: string } });
+      },
+      logger: { info: vi.fn(), warn: vi.fn() },
+    };
+    const client = { isHealthy: vi.fn(() => true) };
+    const discordHistory = {
+      isAvailable: () => true,
+      describeAvailability: () => "ok",
+      readHistory: vi.fn(async () => ({
+        available: true,
+        total: 1,
+        messages: [
+          {
+            messageId: "m1",
+            guildId: "g1",
+            channelId: "c1",
+            channelName: "general",
+            authorId: "u1",
+            authorName: "Alice",
+            content: "Need to ship the Discord bridge",
+            createdAt: "2026-04-07T01:00:00Z",
+            hasAttachments: false,
+            pinned: false,
+          },
+        ],
+      })),
+    };
+
+    registerMentatTools(
+      api,
+      client as never,
+      {
+        mentatUrl: "http://localhost:7832",
+        enabled: true,
+        autoIndex: true,
+        autoRecall: true,
+        autoCapture: false,
+        compressResults: true,
+        compressThresholdTokens: 2000,
+        chatHistory: true,
+        discordHistory: true,
+        discrawlDbPath: "/tmp/discrawl.db",
+        discordHistoryExportDir: "/tmp/discord-export",
+      },
+      new ActiveSessionTracker(),
+      "/tmp/indexed",
+      discordHistory as never,
+    );
+
+    const tool = tools.find((item) => item.opts.name === "read_discord_history")!;
+    const result = await (
+      tool.tool as { execute: (id: string, params: unknown) => Promise<unknown> }
+    ).execute("call1", { channel: "general", last_n: 20 });
+    expect(discordHistory.readHistory).toHaveBeenCalledWith({ channel: "general", last_n: 20 });
+    expect((result as { content: Array<{ text: string }> }).content[0].text).toContain(
+      "Need to ship the Discord bridge",
+    );
   });
 });
 
@@ -2249,6 +2629,7 @@ describe("regression: graceful degradation", () => {
     const { SessionReadTracker, DocMetaCache } = await import("./session-state.js");
 
     const unhealthyClient = {
+      ensureStarted: vi.fn(async () => {}),
       isHealthy: () => false,
       indexFileAsync: vi.fn(),
       indexContentAsync: vi.fn(),

--- a/extensions/mentat-bridge/index.ts
+++ b/extensions/mentat-bridge/index.ts
@@ -4,6 +4,10 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/mentat-bridge";
 import { registerMentatCli } from "./cli.js";
 import { MentatClient } from "./client.js";
 import { mentatBridgeConfigSchema } from "./config.js";
+import {
+  buildDiscordHistoryCollectionConfig,
+  DiscrawlDiscordHistoryBridge,
+} from "./discord-history.js";
 import { registerAfterToolCallHook } from "./hooks/after-tool-call.js";
 import { registerAgentEndHook } from "./hooks/agent-end.js";
 import { registerCompactionHooks } from "./hooks/compaction.js";
@@ -27,7 +31,11 @@ import {
 } from "./session-state.js";
 import { registerMentatTools } from "./tools.js";
 
-async function ensureDefaultCollections(client: MentatClient, chatHistory: boolean) {
+async function ensureDefaultCollections(
+  client: MentatClient,
+  chatHistory: boolean,
+  discordHistoryExportDir?: string,
+) {
   // memory: auto-collect memory_store + memory file changes
   await client.createCollection("memory", {
     metadata: { type: "system", description: "Long-term memory" },
@@ -64,6 +72,13 @@ async function ensureDefaultCollections(client: MentatClient, chatHistory: boole
       watch_ignore: ["_offsets.json"],
     });
   }
+
+  if (discordHistoryExportDir) {
+    await client.createCollection(
+      "discord_history",
+      buildDiscordHistoryCollectionConfig(discordHistoryExportDir),
+    );
+  }
 }
 
 const mentatBridgePlugin = {
@@ -87,6 +102,14 @@ const mentatBridgePlugin = {
     const sessionsDir = join(homedir(), ".openclaw", "agents", "main", "sessions");
     const continuationStore = new ContinuationBriefStore(join(sessionsDir, ".continuation"));
     const sessionCleaner = new SessionCleaner(sessionsDir, api.logger);
+    const discordHistory = new DiscrawlDiscordHistoryBridge(
+      {
+        enabled: cfg.discordHistory,
+        dbPath: cfg.discrawlDbPath,
+        exportDir: cfg.discordHistoryExportDir,
+      },
+      api.logger,
+    );
 
     // ── Service lifecycle ──────────────────────────────────────────
 
@@ -95,7 +118,14 @@ const mentatBridgePlugin = {
       async start() {
         await client.start();
         if (client.isHealthy()) {
-          await ensureDefaultCollections(client, cfg.chatHistory);
+          if (cfg.discordHistory) {
+            await discordHistory.start();
+          }
+          await ensureDefaultCollections(
+            client,
+            cfg.chatHistory,
+            cfg.discordHistory ? cfg.discordHistoryExportDir : undefined,
+          );
           if (cfg.chatHistory) {
             await sessionCleaner.start();
           }
@@ -105,6 +135,7 @@ const mentatBridgePlugin = {
         }
       },
       stop() {
+        discordHistory.stop();
         sessionCleaner.stop();
         client.stop();
         api.logger.info("mentat-bridge: stopped");
@@ -200,6 +231,7 @@ const mentatBridgePlugin = {
       cfg,
       activeSessionTracker,
       indexedDir,
+      discordHistory,
     );
 
     // ── CLI ─────────────────────────────────────────────────────────

--- a/extensions/mentat-bridge/openclaw.plugin.json
+++ b/extensions/mentat-bridge/openclaw.plugin.json
@@ -32,6 +32,22 @@
       "placeholder": "2000",
       "advanced": true,
       "help": "Files smaller than this are kept as-is"
+    },
+    "discordHistory": {
+      "label": "Enable Discord History",
+      "help": "Index discrawl's mirrored Discord archive into Mentat for agent search"
+    },
+    "discrawlDbPath": {
+      "label": "discrawl DB Path",
+      "placeholder": "~/.discrawl/discrawl.db",
+      "advanced": true,
+      "help": "Path to the discrawl SQLite database"
+    },
+    "discordHistoryExportDir": {
+      "label": "Discord Export Dir",
+      "placeholder": "~/.openclaw/mentat/discord-history",
+      "advanced": true,
+      "help": "Directory where mentat-bridge writes append-mode JSONL files for Mentat watcher"
     }
   },
   "configSchema": {
@@ -44,7 +60,11 @@
       "autoRecall": { "type": "boolean" },
       "autoCapture": { "type": "boolean" },
       "compressResults": { "type": "boolean" },
-      "compressThresholdTokens": { "type": "number", "minimum": 500, "maximum": 50000 }
+      "compressThresholdTokens": { "type": "number", "minimum": 500, "maximum": 50000 },
+      "chatHistory": { "type": "boolean" },
+      "discordHistory": { "type": "boolean" },
+      "discrawlDbPath": { "type": "string" },
+      "discordHistoryExportDir": { "type": "string" }
     }
   }
 }

--- a/extensions/mentat-bridge/source-map.ts
+++ b/extensions/mentat-bridge/source-map.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 /** Map OpenClaw tool names to Mentat source tags for provenance tracking. */
 export function toolToSource(toolName: string): string {
   if (toolName === "WebFetch" || toolName === "web_fetch") return "web_fetch";
@@ -21,6 +23,48 @@ export function isWebFetchTool(toolName: string): boolean {
 
 export function isComposioTool(toolName: string): boolean {
   return toolName.startsWith("composio:");
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80);
+}
+
+function stableScalarParamHash(params: Record<string, unknown>): string | null {
+  const scalars = Object.entries(params)
+    .filter(([, value]) => ["string", "number", "boolean"].includes(typeof value))
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  if (scalars.length === 0) return null;
+
+  const payload = JSON.stringify(Object.fromEntries(scalars));
+  return createHash("sha1").update(payload).digest("hex").slice(0, 10);
+}
+
+/**
+ * Build a stable filename for Composio tool outputs so repeated reads of the
+ * same resource dedupe cleanly in Mentat.
+ */
+export function composioFilename(
+  toolName: string,
+  params: Record<string, unknown>,
+  toolCallId?: string,
+): string {
+  const base = sanitizeFilenamePart(toolName.replace(/:/g, "_"));
+
+  for (const [key, value] of Object.entries(params)) {
+    if (
+      typeof value === "string" &&
+      value &&
+      (key === "id" || key.endsWith("_id") || /[a-z]Id$/.test(key))
+    ) {
+      return `${base}-${sanitizeFilenamePart(value)}.md`;
+    }
+  }
+
+  const hash = stableScalarParamHash(params);
+  if (hash) return `${base}-${hash}.md`;
+
+  return `${base}-${sanitizeFilenamePart(toolCallId ?? "unknown")}.md`;
 }
 
 /**

--- a/extensions/mentat-bridge/tools.ts
+++ b/extensions/mentat-bridge/tools.ts
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 import { Type } from "@sinclair/typebox";
 import type { MentatClient } from "./client.js";
 import type { MentatBridgeConfig } from "./config.js";
+import { summarizeDiscordMessages, type DiscrawlDiscordHistoryBridge } from "./discord-history.js";
 import type { ActiveSessionTracker } from "./session-state.js";
 
 type PluginApi = {
@@ -27,6 +28,7 @@ export function registerMentatTools(
   _cfg: MentatBridgeConfig,
   activeSessionTracker: ActiveSessionTracker,
   indexedDir: string,
+  discordHistory?: DiscrawlDiscordHistoryBridge,
 ) {
   // 1. search_memory — unified search (replaces memory_recall + memory_search + memory_get)
   api.registerTool(
@@ -681,5 +683,262 @@ export function registerMentatTools(
       },
     },
     { name: "read_chat_history" },
+  );
+
+  // 10. search_discord_history — search discrawl-backed Discord archive
+  api.registerTool(
+    {
+      name: "search_discord_history",
+      label: "Search Discord History",
+      description:
+        "Search the connected Discord server history mirrored by discrawl and indexed into Mentat. This covers overall guild chat history, not just the current agent session.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Natural language search query" }),
+        top_k: Type.Optional(Type.Number({ description: "Maximum results (default: 5)" })),
+        channel: Type.Optional(
+          Type.String({
+            description:
+              "Optional channel name/id hint; applied as a lightweight post-filter on search results",
+          }),
+        ),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: { query: string; top_k?: number; channel?: string },
+      ) {
+        if (!discordHistory?.isAvailable()) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  discordHistory?.describeAvailability() ??
+                  "Discord history archive is not configured.",
+              },
+            ],
+            details: { error: "discord_history_unavailable" },
+          };
+        }
+        if (!client.isHealthy()) return unhealthyResult("search_discord_history");
+
+        const channelHint = params.channel?.trim().toLowerCase();
+        const rawResults = await client.search({
+          query: params.query,
+          top_k: Math.max(params.top_k ?? 5, 1),
+          collection: discordHistory.collectionName,
+          hybrid: true,
+        });
+        if (!rawResults || rawResults.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No matching Discord history found." }],
+            details: { count: 0 },
+          };
+        }
+
+        const filtered = channelHint
+          ? rawResults.filter((result) => {
+              const haystack =
+                `${result.filename ?? ""}\n${result.content ?? ""}\n${result.summary ?? ""}`.toLowerCase();
+              return haystack.includes(channelHint);
+            })
+          : rawResults;
+
+        if (filtered.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `No Discord history matched channel hint "${params.channel}".`,
+              },
+            ],
+            details: { count: 0 },
+          };
+        }
+
+        const text = filtered
+          .map((result, index) => {
+            const snippet = result.content ?? result.summary ?? "";
+            return `${index + 1}. ${result.filename} [score: ${result.score.toFixed(4)}]\n${snippet}`;
+          })
+          .join("\n\n");
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Found ${filtered.length} Discord history result(s):\n\n${text}`,
+            },
+          ],
+          details: { count: filtered.length, results: filtered },
+        };
+      },
+    },
+    { name: "search_discord_history" },
+  );
+
+  // 11. read_discord_history — read exact messages from discrawl SQLite
+  api.registerTool(
+    {
+      name: "read_discord_history",
+      label: "Read Discord History",
+      description:
+        "Read exact messages from the discrawl Discord archive by channel, author, or recent time window. Useful after search_discord_history when you need raw surrounding chat.",
+      parameters: Type.Object({
+        channel: Type.Optional(
+          Type.String({
+            description: "Channel id or name (for example 'test' or '1489512128640585728')",
+          }),
+        ),
+        author: Type.Optional(
+          Type.String({ description: "Optional author id or display name filter" }),
+        ),
+        last_n: Type.Optional(
+          Type.Number({ description: "Number of messages to return (default: 50, max: 200)" }),
+        ),
+        since: Type.Optional(
+          Type.String({ description: "RFC3339 timestamp lower bound, e.g. 2026-04-01T00:00:00Z" }),
+        ),
+        hours: Type.Optional(
+          Type.Number({ description: "Shortcut for messages from the last N hours" }),
+        ),
+        days: Type.Optional(
+          Type.Number({ description: "Shortcut for messages from the last N days" }),
+        ),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: {
+          channel?: string;
+          author?: string;
+          last_n?: number;
+          since?: string;
+          hours?: number;
+          days?: number;
+        },
+      ) {
+        if (!discordHistory) {
+          return {
+            content: [
+              { type: "text" as const, text: "Discord history archive is not configured." },
+            ],
+            details: { error: "discord_history_unavailable" },
+          };
+        }
+
+        const result = await discordHistory.readHistory(params);
+        if (!result.available) {
+          return {
+            content: [
+              { type: "text" as const, text: result.error ?? "Discord history is unavailable." },
+            ],
+            details: { error: "discord_history_unavailable" },
+          };
+        }
+        if (!result.messages || result.messages.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No Discord messages matched that request." }],
+            details: { count: 0 },
+          };
+        }
+
+        return {
+          content: [{ type: "text" as const, text: summarizeDiscordMessages(result.messages) }],
+          details: {
+            count: result.messages.length,
+            total: result.total,
+            messages: result.messages,
+          },
+        };
+      },
+    },
+    { name: "read_discord_history" },
+  );
+
+  // 12. read_wiki_link — resolve a Mentat wiki URL and read its content
+  api.registerTool(
+    {
+      name: "read_wiki_link",
+      label: "Read Wiki Link",
+      description:
+        "Read content from a Mentat wiki URL the user pasted. Resolves the URL to the indexed source document and (optionally) the specific section, then returns the content. Accepts full URLs (http://localhost:7832/wiki/pages/<id>#section), path-only (/wiki/pages/<id>#section), or short form (<id>#section).",
+      parameters: Type.Object({
+        url: Type.String({ description: "Wiki URL or page id (with optional #section anchor)" }),
+      }),
+      async execute(_toolCallId: string, params: { url: string }) {
+        if (!client.isHealthy()) return unhealthyResult("read_wiki_link");
+
+        const resolved = await client.resolveWikiUrl(params.url);
+        if (!resolved) {
+          const wikiText = await client.fetchWikiText(params.url);
+          if (wikiText) {
+            return {
+              content: [{ type: "text" as const, text: wikiText }],
+              details: { mode: "wiki_html_fallback", url: params.url },
+            };
+          }
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Could not resolve wiki URL: ${params.url}`,
+              },
+            ],
+            details: { error: "resolve_failed" },
+          };
+        }
+
+        // If no section, fall back to doc meta + brief overview
+        if (!resolved.section_path) {
+          const meta = await client.getDocMeta(resolved.doc_id);
+          if (!meta) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Resolved to ${resolved.filename} (${resolved.doc_id}) but document metadata is unavailable.`,
+                },
+              ],
+              details: { resolved },
+            };
+          }
+          const tocList = (meta.toc_entries ?? []).map((e) => `  - ${e.title}`).join("\n");
+          const text = `Wiki page: ${meta.filename} (${resolved.doc_id})\n\n${meta.brief_intro ?? ""}\n\nSections:\n${tocList || "  (none)"}\n\nUse \`read_segment\` with a section name to read content.`;
+          return {
+            content: [{ type: "text" as const, text }],
+            details: { resolved, meta },
+          };
+        }
+
+        // Section specified — read it directly
+        const segment = await client.readSegment({
+          doc_id: resolved.doc_id,
+          section_path: resolved.section_path,
+        });
+
+        if (!segment) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Resolved to ${resolved.filename} > ${resolved.section_path}, but section read failed.`,
+              },
+            ],
+            details: { resolved, error: "read_segment_failed" },
+          };
+        }
+
+        const parts: string[] = [`Wiki: ${resolved.filename} > ${resolved.section_path}`, ""];
+        for (const chunk of segment.chunks) {
+          if (chunk.content) parts.push(chunk.content);
+        }
+        if (segment.note) parts.push(`\n_${segment.note}_`);
+
+        return {
+          content: [{ type: "text" as const, text: parts.join("\n") }],
+          details: { resolved, segment },
+        };
+      },
+    },
+    { name: "read_wiki_link" },
   );
 }

--- a/extensions/mentat-bridge/types.ts
+++ b/extensions/mentat-bridge/types.ts
@@ -178,6 +178,14 @@ export type HealthResponse = {
   version?: string;
 };
 
+// ── Wiki ─────────────────────────────────────────────────────────────
+
+export type WikiResolveResponse = {
+  doc_id: string;
+  section_path: string | null;
+  filename: string;
+};
+
 // ── Stats ────────────────────────────────────────────────────────────
 
 export type StatsResponse = {


### PR DESCRIPTION
## Summary

This extends `extensions/mentat-bridge` with two user-facing retrieval paths that build on the existing Mentat integration:

- add Discord history support, including config, archive reading/export plumbing, and a `read_discord_history` tool
- add wiki link resolution and reading support so pasted Mentat wiki URLs can be resolved back to indexed docs/sections via `read_wiki_link`
- wire the new behavior through the client, source mapping, plugin schema, and tests

## Why

The previous Mentat bridge could search indexed memory, but it was still awkward to:

- retrieve mirrored Discord conversation history from discrawl-backed archives
- follow a Mentat wiki URL pasted by a user and turn it into readable document/section content inside the agent

This PR closes both gaps directly in the extension layer.

## Validation

- `pnpm vitest run extensions/mentat-bridge/index.test.ts`

## Notes

- based on `phala-2026.3.13`
- published from branch `mentat-bridge-discord-history`
