### PR TITLE
fix(mentat-bridge): resolve TypeScript errors in CI

### DIFF
--- a/extensions/mentat-bridge/cli.ts
+++ b/extensions/mentat-bridge/cli.ts
@@ -36,12 +36,9 @@ export function registerMentatCli(api: PluginApi, client: MentatClient) {
 
           const stats = await client.getStats();
           if (stats) {
-            console.log(`  Documents: ${stats.total_docs}`);
-            console.log(`  Chunks: ${stats.total_chunks}`);
-            console.log(`  Collections: ${stats.total_collections}`);
-            if (stats.pending_tasks != null) {
-              console.log(`  Pending tasks: ${stats.pending_tasks}`);
-            }
+            console.log(`  Documents: ${stats.docs_indexed}`);
+            console.log(`  Chunks: ${stats.chunks_stored}`);
+            console.log(`  Collections: ${stats.collections}`);
           }
         });
 

--- a/extensions/mentat-bridge/index.test.ts
+++ b/extensions/mentat-bridge/index.test.ts
@@ -376,7 +376,7 @@ describe("prompt", () => {
     const { fetchSkillPrompt } = await import("./prompt.js");
     const mockClient = { getSkillPrompt: vi.fn(async () => null) };
     const result = await fetchSkillPrompt(mockClient as never);
-    expect(result).toContain("Memory System (Mentat)");
+    expect(result).toContain("Document Intelligence System (Mentat)");
     expect(result).toContain("search_memory");
   });
 
@@ -1025,6 +1025,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(),
         isHealthy: vi.fn(() => true),
         indexFileAsync: vi.fn(),
         getDocMeta: vi.fn(async () => ({ doc_id: "d1", filename: "test.ts" })),
@@ -1032,7 +1033,7 @@ describe("hooks", () => {
       const tracker = new SessionReadTracker();
       const cache = new DocMetaCache();
 
-      registerAfterToolCallHook(api, client as never, tracker, cache);
+      registerAfterToolCallHook(api as never, client as never, tracker, cache);
       expect(handlers).toHaveLength(1);
 
       await handlers[0](
@@ -1071,7 +1072,12 @@ describe("hooks", () => {
         })),
       };
 
-      registerAfterToolCallHook(api, client as never, new SessionReadTracker(), new DocMetaCache());
+      registerAfterToolCallHook(
+        api as never,
+        client as never,
+        new SessionReadTracker(),
+        new DocMetaCache(),
+      );
 
       await handlers[0](
         {
@@ -1099,11 +1105,17 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(),
         isHealthy: vi.fn(() => false),
         indexFileAsync: vi.fn(),
       };
 
-      registerAfterToolCallHook(api, client as never, new SessionReadTracker(), new DocMetaCache());
+      registerAfterToolCallHook(
+        api as never,
+        client as never,
+        new SessionReadTracker(),
+        new DocMetaCache(),
+      );
 
       await handlers[0]({ toolName: "Read", params: { path: "/test.ts" } }, { sessionKey: "s1" });
       expect(client.indexFileAsync).not.toHaveBeenCalled();
@@ -1121,11 +1133,17 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(),
         isHealthy: vi.fn(() => true),
         indexFileAsync: vi.fn(),
       };
 
-      registerAfterToolCallHook(api, client as never, new SessionReadTracker(), new DocMetaCache());
+      registerAfterToolCallHook(
+        api as never,
+        client as never,
+        new SessionReadTracker(),
+        new DocMetaCache(),
+      );
 
       await handlers[0](
         { toolName: "Read", params: { path: "/test.ts" }, error: "file not found" },
@@ -1151,7 +1169,12 @@ describe("hooks", () => {
         indexContentAsync: vi.fn(),
       };
 
-      registerAfterToolCallHook(api, client as never, new SessionReadTracker(), new DocMetaCache());
+      registerAfterToolCallHook(
+        api as never,
+        client as never,
+        new SessionReadTracker(),
+        new DocMetaCache(),
+      );
 
       // With resource ID param → stable filename
       await handlers[0](
@@ -1237,7 +1260,13 @@ describe("hooks", () => {
       })) as unknown as typeof fetch;
 
       try {
-        registerTransformToolResultHook(api, client as never, cfg as never, tracker, cache);
+        registerTransformToolResultHook(
+          api as never,
+          client as never,
+          cfg as never,
+          tracker,
+          cache,
+        );
         expect(handlers).toHaveLength(1);
 
         // Simulate a large WebFetch result (> 100 tokens = 400 chars)
@@ -1305,7 +1334,7 @@ describe("hooks", () => {
       const cfg = { compressThresholdTokens: 5000 }; // high threshold
 
       registerTransformToolResultHook(
-        api,
+        api as never,
         client as never,
         cfg as never,
         new SessionReadTracker(),
@@ -1348,7 +1377,7 @@ describe("hooks", () => {
       };
 
       registerTransformToolResultHook(
-        api,
+        api as never,
         client as never,
         { compressThresholdTokens: 100 } as never,
         new SessionReadTracker(),
@@ -1389,7 +1418,7 @@ describe("hooks", () => {
       };
 
       registerTransformToolResultHook(
-        api,
+        api as never,
         client as never,
         { compressThresholdTokens: 100 } as never,
         new SessionReadTracker(),
@@ -1434,7 +1463,7 @@ describe("hooks", () => {
 
       try {
         registerTransformToolResultHook(
-          api,
+          api as never,
           client as never,
           { compressThresholdTokens: 100 } as never,
           new SessionReadTracker(),
@@ -1485,7 +1514,7 @@ describe("hooks", () => {
         ],
       });
 
-      registerToolResultPersistHook(api, client, cfg as never, cache);
+      registerToolResultPersistHook(api as never, client, cfg as never, cache);
 
       // Simulate large file read result (> 100 tokens = 400 chars)
       const bigContent = "File: /big-file.ts\n" + "x".repeat(600);
@@ -1518,7 +1547,7 @@ describe("hooks", () => {
       };
 
       registerToolResultPersistHook(
-        api,
+        api as never,
         { isHealthy: () => true },
         { compressThresholdTokens: 100 } as never,
         new DocMetaCache(),
@@ -1547,7 +1576,7 @@ describe("hooks", () => {
       };
 
       registerToolResultPersistHook(
-        api,
+        api as never,
         { isHealthy: () => true },
         { compressThresholdTokens: 100 } as never,
         new DocMetaCache(),
@@ -1573,7 +1602,7 @@ describe("hooks", () => {
       };
 
       registerToolResultPersistHook(
-        api,
+        api as never,
         { isHealthy: () => true },
         { compressThresholdTokens: 2000 } as never,
         new DocMetaCache(),
@@ -1599,7 +1628,7 @@ describe("hooks", () => {
       };
 
       registerToolResultPersistHook(
-        api,
+        api as never,
         { isHealthy: () => false },
         { compressThresholdTokens: 100 } as never,
         new DocMetaCache(),
@@ -1625,11 +1654,12 @@ describe("hooks", () => {
         logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(),
         isHealthy: vi.fn(() => true),
         indexContent: vi.fn(async () => ({ doc_id: "c1", filename: "auto.md", status: "ok" })),
       };
 
-      registerAgentEndHook(api, client as never);
+      registerAgentEndHook(api as never, client as never);
 
       await handlers[0](
         {
@@ -1663,11 +1693,12 @@ describe("hooks", () => {
         logger: { info: vi.fn(), warn: vi.fn() },
       };
       const client = {
+        ensureStarted: vi.fn(),
         isHealthy: vi.fn(() => true),
         indexContent: vi.fn(async () => ({ doc_id: "c1", filename: "auto.md", status: "ok" })),
       };
 
-      registerAgentEndHook(api, client as never);
+      registerAgentEndHook(api as never, client as never);
 
       await handlers[0](
         {
@@ -1697,9 +1728,13 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => false), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(),
+        isHealthy: vi.fn(() => false),
+        indexContent: vi.fn(),
+      };
 
-      registerAgentEndHook(api, client as never);
+      registerAgentEndHook(api as never, client as never);
 
       await handlers[0](
         { success: true, messages: [{ role: "user", content: "I prefer dark mode always" }] },
@@ -1718,9 +1753,13 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => true), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(),
+        isHealthy: vi.fn(() => true),
+        indexContent: vi.fn(),
+      };
 
-      registerAgentEndHook(api, client as never);
+      registerAgentEndHook(api as never, client as never);
 
       await handlers[0](
         { success: false, messages: [{ role: "user", content: "I prefer dark mode always" }] },
@@ -1739,9 +1778,13 @@ describe("hooks", () => {
         },
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      const client = { isHealthy: vi.fn(() => true), indexContent: vi.fn() };
+      const client = {
+        ensureStarted: vi.fn(),
+        isHealthy: vi.fn(() => true),
+        indexContent: vi.fn(),
+      };
 
-      registerAgentEndHook(api, client as never);
+      registerAgentEndHook(api as never, client as never);
 
       await handlers[0](
         {
@@ -1772,7 +1815,7 @@ describe("hooks", () => {
       tracker.trackRead("s1", "d1");
       tracker.trackRead("s1", "d2");
 
-      registerCompactionHooks(api, {} as never, tracker);
+      registerCompactionHooks(api as never, {} as never, tracker);
 
       await handlers[0]({}, { sessionKey: "s1" });
       expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("2 docs tracked"));
@@ -1790,7 +1833,7 @@ describe("hooks", () => {
         logger: { info: vi.fn(), debug: vi.fn() },
       };
 
-      registerCompactionHooks(api, {} as never, new SessionReadTracker());
+      registerCompactionHooks(api as never, {} as never, new SessionReadTracker());
 
       await handlers[0]({}, {});
       expect(api.logger.info).not.toHaveBeenCalled();
@@ -2250,6 +2293,7 @@ describe("regression: graceful degradation", () => {
 
     const unhealthyClient = {
       isHealthy: () => false,
+      ensureStarted: vi.fn(),
       indexFileAsync: vi.fn(),
       indexContentAsync: vi.fn(),
       indexContent: vi.fn(),
@@ -2265,7 +2309,7 @@ describe("regression: graceful degradation", () => {
         logger: { debug: vi.fn() },
       };
       registerAfterToolCallHook(
-        api,
+        api as never,
         unhealthyClient as never,
         new SessionReadTracker(),
         new DocMetaCache(),
@@ -2282,7 +2326,7 @@ describe("regression: graceful degradation", () => {
           handlers.push(h),
         logger: { info: vi.fn(), warn: vi.fn() },
       };
-      registerAgentEndHook(api, unhealthyClient as never);
+      registerAgentEndHook(api as never, unhealthyClient as never);
       await handlers[0](
         { success: true, messages: [{ role: "user", content: "I prefer dark mode always" }] },
         {},

--- a/extensions/mentat-bridge/session-cleaner.ts
+++ b/extensions/mentat-bridge/session-cleaner.ts
@@ -218,11 +218,11 @@ export class SessionCleaner {
   readonly indexedDir: string;
   private offsets: PersistedOffsets = {};
   private timer: ReturnType<typeof setInterval> | null = null;
-  private logger: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void };
+  private logger: { info: (message: string) => void; warn: (message: string) => void };
 
   constructor(
     rawDir: string,
-    logger?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void },
+    logger?: { info: (message: string) => void; warn: (message: string) => void },
   ) {
     this.rawDir = rawDir;
     this.indexedDir = join(rawDir, ".indexed");

--- a/extensions/mentat-bridge/source-map.ts
+++ b/extensions/mentat-bridge/source-map.ts
@@ -23,6 +23,42 @@ export function isComposioTool(toolName: string): boolean {
   return toolName.startsWith("composio:");
 }
 
+/** Build a stable, dedup-friendly filename for a Composio tool result. */
+export function composioFilename(
+  toolName: string,
+  params: Record<string, unknown>,
+  toolCallId?: string,
+): string {
+  const prefix = toolName.replace(/:/g, "_");
+
+  // Look for an ID-like param (exact "id", ends with "_id", or camelCase "Id")
+  const idKey = Object.keys(params).find(
+    (k) => k === "id" || k.endsWith("_id") || k.endsWith("Id"),
+  );
+  if (idKey && typeof params[idKey] === "string") {
+    return `${prefix}-${params[idKey]}.md`;
+  }
+
+  // Hash scalar params for stable dedup when no explicit ID
+  const scalars = Object.entries(params)
+    .filter(([, v]) => typeof v === "string" || typeof v === "number")
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&");
+  if (scalars) {
+    // Simple FNV-1a-like hash to keep filenames short
+    let h = 0x811c9dc5;
+    for (let i = 0; i < scalars.length; i++) {
+      h ^= scalars.charCodeAt(i);
+      h = Math.imul(h, 0x01000193);
+    }
+    return `${prefix}-${(h >>> 0).toString(16)}.md`;
+  }
+
+  // Fallback to toolCallId
+  return `${prefix}-${toolCallId ?? "unknown"}.md`;
+}
+
 /**
  * Try to unwrap a JSON string into its nested text content.
  * Tool results like WebFetch arrive as `{ content: [{ type: "text", text: JSON.stringify(payload) }] }`

--- a/extensions/mentat-bridge/types.ts
+++ b/extensions/mentat-bridge/types.ts
@@ -61,6 +61,7 @@ export type MentatSearchResult = {
   instructions?: string;
   score: number;
   source?: string;
+  session_id?: string;
   metadata?: Record<string, unknown>;
 };
 


### PR DESCRIPTION
- Add missing composioFilename export to source-map.ts
- Fix StatsResponse field names in cli.ts (total_docs → docs_indexed, etc.)
- Add session_id to MentatSearchResult type
- Narrow SessionCleaner logger type to match PluginLogger
- Fix test mock PluginApi type mismatches with `as never` casts
- Add missing ensureStarted to test mock clients
- Update stale fallback prompt assertion in test

