### PR TITLE
ci: add workflow_dispatch with custom tags for test image builds

### DIFF
--- a/.github/workflows/docker-release-phala.yml
+++ b/.github/workflows/docker-release-phala.yml
@@ -11,6 +11,12 @@ on:
       - ".agents/**"
       - "skills/**"
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Custom image tag override (e.g. test-imessage-abc1234). When set, skips ref validation."
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: docker-release-phala-${{ github.ref }}
@@ -33,8 +39,12 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          FULL_VERSION="$(bash phala-deploy/release-meta.sh full-version package.json)"
-          bash phala-deploy/release-meta.sh validate-ref "$FULL_VERSION" "$GITHUB_REF" "$GITHUB_REF_NAME" >/dev/null
+          if [[ -n "${{ inputs.image_tag }}" ]]; then
+            FULL_VERSION="${{ inputs.image_tag }}"
+          else
+            FULL_VERSION="$(bash phala-deploy/release-meta.sh full-version package.json)"
+            bash phala-deploy/release-meta.sh validate-ref "$FULL_VERSION" "$GITHUB_REF" "$GITHUB_REF_NAME" >/dev/null
+          fi
           echo "full=$FULL_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -57,10 +67,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MUX_LC }}
           tags: |
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=${{ steps.version.outputs.full }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{version}},suffix=-amd64,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=${{ steps.version.outputs.full }}-amd64,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},enable=${{ inputs.image_tag == '' && startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ steps.version.outputs.full }},enable=${{ inputs.image_tag != '' || startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},suffix=-amd64,enable=${{ inputs.image_tag == '' && startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ steps.version.outputs.full }}-amd64,enable=${{ inputs.image_tag != '' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push mux amd64 image
         uses: docker/build-push-action@v6

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -4,9 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish tarball under (e.g. test-imessage-abc1234). Creates a pre-release."
+        required: true
+        type: string
 
 concurrency:
-  group: openclaw-release-${{ github.ref }}
+  group: openclaw-release-${{ github.ref }}-${{ inputs.release_tag || '' }}
   cancel-in-progress: false
 
 env:
@@ -48,7 +54,18 @@ jobs:
           TGZ_PATH="/tmp/$(printf '%s\n' "$PACK_OUT" | tail -n 1 | tr -d '[:space:]')"
           mv -f "$TGZ_PATH" /tmp/openclaw.tgz
 
-          TAG="${GITHUB_REF_NAME}"
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          gh release create "$TAG" --title "openclaw $PACKAGE_VERSION" --notes "" 2>/dev/null || true
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            # Manual dispatch: create a pre-release with the provided tag
+            TAG="${{ inputs.release_tag }}"
+            gh release create "$TAG" \
+              --title "openclaw $PACKAGE_VERSION ($TAG)" \
+              --notes "Pre-release build from branch $GITHUB_REF_NAME (commit $GITHUB_SHA)" \
+              --prerelease \
+              --target "$GITHUB_SHA" 2>/dev/null || true
+          else
+            # Tag push: use the git tag name
+            TAG="${GITHUB_REF_NAME}"
+            gh release create "$TAG" --title "openclaw $PACKAGE_VERSION" --notes "" 2>/dev/null || true
+          fi
           gh release upload "$TAG" /tmp/openclaw.tgz --clobber


### PR DESCRIPTION
## Summary

Enable building test images from non-main branches without needing to tag releases.

## Changes

- **`openclaw-npm-release.yml`**: adds `workflow_dispatch` with `release_tag` input. When dispatched manually, creates a pre-release targeting the current commit SHA (supports non-default branches via `--target`).

- **`docker-release-phala.yml`**: adds `image_tag` input. When set, skips `validate-ref` and uses the custom tag for the mux-server Docker image instead of the semver version.

## Why

The current release workflows only trigger on `v*` tag push, which requires:
1. Bumping `package.json` version
2. Tagging on a `phala-*` or `v*` ref

This blocks us from building test images off feature branches (e.g. #88 iMessage integration) before merging.

With these inputs, we can do:

\`\`\`bash
gh workflow run openclaw-npm-release.yml --ref feat/imessage-mux-transport \\
  -f release_tag=test-imessage-abc1234

gh workflow run docker-release-phala.yml --ref feat/imessage-mux-transport \\
  -f image_tag=test-imessage-abc1234
\`\`\`

No production behavior changes — existing tag-push paths are unchanged.

## Related

- Clawdi-AI/openclaw#88 (iMessage integration — needs test images)

## Test plan

- [x] Lint: workflow YAML syntactically valid
- [ ] Dry run: trigger via \`gh workflow run\` after merge, confirm custom tag flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)