### PR TITLE
whatsapp: preserve raw mux inbound `to` for non-LID targets

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,6 +1,54 @@
 import { describe, expect, it } from "vitest";
 import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
 
+describe("session delivery preserves whatsapp chatJid for mux routing", () => {
+  // Regression: the mux-server binds by chatJid (e.g. Baileys JIDs like
+  // `15105989468:0@s.whatsapp.net`). Any rewrite of originatingTo or
+  // persistedLastTo along the reply / cron path produces a mismatched
+  // chatJid and a 403 "route not bound".
+
+  const baileysJid = "whatsapp:15105989468:0@s.whatsapp.net";
+
+  it("preserves a fresh inbound whatsapp JID for the reply path", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "whatsapp",
+        originatingToRaw: baileysJid,
+        persistedLastChannel: "whatsapp",
+        persistedLastTo: undefined,
+        sessionKey: "agent:main:main",
+      }),
+    ).toBe(baileysJid);
+  });
+
+  it("preserves a persisted whatsapp JID for the cron path (no fresh inbound)", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: undefined,
+        originatingToRaw: undefined,
+        persistedLastChannel: "whatsapp",
+        persistedLastTo: baileysJid,
+        sessionKey: "agent:main:cron:job-1",
+      }),
+    ).toBe(baileysJid);
+  });
+
+  it("preserves a persisted whatsapp JID when a cron turn's internal origin is webchat", () => {
+    // Cron jobs often run with an internal/webchat-like origin for the
+    // current turn, but should still deliver back over the previously
+    // known external whatsapp route without rewriting the chatJid.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:dashboard",
+        persistedLastChannel: "whatsapp",
+        persistedLastTo: baileysJid,
+        sessionKey: "agent:main:cron:job-1",
+      }),
+    ).toBe(baileysJid);
+  });
+});
+
 describe("session delivery direct-session routing overrides", () => {
   it.each([
     "agent:main:direct:user-1",

--- a/src/gateway/mux-http.test.ts
+++ b/src/gateway/mux-http.test.ts
@@ -796,19 +796,13 @@ describe("handleMuxInboundHttpRequest", () => {
       expect(await handleMuxInboundHttpRequest(req, res)).toBe(true);
       expect(res.statusCode).toBe(202);
       await waitForAsyncDispatch();
-      const expectedTypingTarget =
-        channel === "discord"
-          ? "user:42"
-          : channel === "whatsapp"
-            ? "whatsapp:+42"
-            : "telegram:123";
       expect(mocks.sendTypingViaMux).toHaveBeenCalledWith(
         expect.objectContaining({
           cfg: expect.any(Object),
           channel,
           accountId: "default",
           sessionKey: "agent:main:main",
-          to: expectedTypingTarget,
+          to: channel === "discord" ? "user:42" : `${channel}:123`,
         }),
       );
     },
@@ -1058,7 +1052,35 @@ describe("handleMuxInboundHttpRequest", () => {
         sessionKey: "agent:main:main",
         surface: "mux",
         originatingChannel: "whatsapp",
-        originatingTo: "whatsapp:+15550001111",
+        // The raw mux inbound `to` is preserved verbatim so that the reply
+        // path fed to the mux-server carries a chatJid which matches the
+        // binding's routeKey. Over-normalizing (e.g. to the sender E164)
+        // makes the mux-server's target-based route lookup rewrite the
+        // chatJid and miss the binding with a 403 route-not-bound.
+        originatingTo: "whatsapp:+15551230000",
+        messageThreadId: undefined,
+      },
+    },
+    {
+      // Regression: standard Baileys JID in `payload.to` (including the
+      // optional `:0` device suffix) must round-trip verbatim into
+      // originatingTo so mux-server can match the binding that was
+      // registered from the same JID.
+      name: "whatsapp dm with baileys JID",
+      body: {
+        channel: "whatsapp",
+        sessionKey: "wa:dm:15105989468@s.whatsapp.net",
+        to: "whatsapp:15105989468:0@s.whatsapp.net",
+        from: "whatsapp:+15105989468",
+        body: "hello from baileys",
+        messageId: "wa-dm-baileys-1",
+      },
+      expected: {
+        accountId: "default",
+        sessionKey: "agent:main:main",
+        surface: "mux",
+        originatingChannel: "whatsapp",
+        originatingTo: "whatsapp:15105989468:0@s.whatsapp.net",
         messageThreadId: undefined,
       },
     },

--- a/src/gateway/mux-http.ts
+++ b/src/gateway/mux-http.ts
@@ -338,6 +338,15 @@ function resolveMuxInboundOriginatingTo(params: {
     return peer.kind === "direct" ? `user:${peer.id}` : `channel:${peer.id}`;
   }
   if (params.channel === "whatsapp") {
+    // Preserve the raw mux inbound `to` so downstream route-key lookup on the
+    // mux-server still matches the binding registered from the exact same
+    // JID (including the optional Baileys device suffix, e.g. `:0`). LID
+    // targets have no phone number and cannot be replied to directly, so fall
+    // back to the sender there.
+    const rawTo = readMuxNonEmptyString(params.payload.to);
+    if (rawTo && !/@lid\b/i.test(rawTo)) {
+      return rawTo;
+    }
     const peer = resolveWhatsAppInboundPeer({ payload: params.payload });
     return peer ? `whatsapp:${peer.id}` : null;
   }


### PR DESCRIPTION
## Summary

Fixes a regression in 2026.3.13-phala.16 where every WhatsApp mux outbound — direct replies *and* cron fires that lean on \`persistedLastTo\` — returns \`403 route not bound\`.

## Root cause

\`ba609a572e\` (\"whatsapp: normalize mux originatingTo\") routes WhatsApp \`originatingTo\` through \`resolveWhatsAppInboundPeer\`, which strips the Baileys device suffix and leaves an E164 like \`whatsapp:+15105989468\`. That value flows into \`ctx.To\` / \`ctx.OriginatingTo\` and becomes the outbound \`to\` on the reply. On the mux-server, \`parseWhatsAppOutboundChatJid\` sees no \`@\`, strips non-digits (losing the \`+\`), and re-appends \`@s.whatsapp.net\` — producing \`<digits>@s.whatsapp.net\`. Bindings registered from the native Baileys JID (e.g. \`15105989468:0@s.whatsapp.net\`) don't match that chatJid, so target-based route lookup returns \`null\` and the request is rejected.

## Fix

In \`resolveMuxInboundOriginatingTo\` (WhatsApp branch):
- Preserve \`payload.to\` verbatim for non-LID targets so the mux-server's route-key lookup still matches the binding it registered from the same JID.
- Fall back to the sender peer only when \`payload.to\` is a LID target (no phone number) or missing — which is the case the normalization was originally added for, and the \"whatsapp dm lid target\" test still covers.

## Tests

- \`src/gateway/mux-http.test.ts\`: revert the two assertions \`ba609a572e\` flipped to the sender E164 (standard DM \`originatingTo\`, typing \`to\`); add a new regression case \"whatsapp dm with baileys JID\" exercising \`15105989468:0@s.whatsapp.net\` — the exact shape that shipped broken.
- \`src/auto-reply/reply/session-delivery.test.ts\`: three new cases asserting \`resolveLastToRaw\` returns a WhatsApp JID verbatim on the reply path, the cron path with no fresh inbound, and the cron path when the current turn's internal origin is webchat (a common cron shape).

## Test plan

- [x] \`src/gateway/mux-http.test.ts\` — 41/41 pass (was 40/40 before, added 1)
- [x] \`src/auto-reply/reply/session-delivery.test.ts\` — 15/15 pass (was 12/12 before, added 3)
- [x] \`src/channels/plugins/outbound/mux-routing.test.ts\` + \`mux-runtime.test.ts\` + \`src/cron/isolated-agent.direct-delivery-core-channels.test.ts\` — 26/26 pass
- [ ] Cut \`v2026.3.13-phala.17\`, rebuild agent image, deploy to hangyin's CVM, verify \`/status\` reply arrives and no queued messages in \`/data/openclaw/delivery-queue\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)