### PR TITLE
mux-server/whatsapp: match outbound routeKeys against all historical chatJid forms

### DIFF
--- a/mux-server/src/routing/keys.ts
+++ b/mux-server/src/routing/keys.ts
@@ -315,23 +315,78 @@ export function parseWhatsAppOutboundChatJid(value: unknown): string | null {
   return `${digits}@s.whatsapp.net`;
 }
 
+/**
+ * Expand an outbound chatJid-shaped value into the set of forms the matching
+ * binding might have been stored under.
+ *
+ * Any chatJid with an `@` (canonical `s.whatsapp.net` JID, `g.us` group, or
+ * `lid` target) is unambiguous and passes through verbatim. Bare-number
+ * inputs are the ambiguous case: bindings have been observed as E164 bare
+ * (`+<digits>`) — the shape the current WhatsApp bridge emits for DMs — and
+ * as the canonical `<digits>@s.whatsapp.net` JID that the historical
+ * `parseWhatsAppOutboundChatJid` always synthesized, which is also the
+ * shape legacy bridge/mux-server paths produced and what the rest of the
+ * suite uses as routeKey fixtures. We return both, input-shape first so
+ * the first-match lookup picks the form that most likely matches the
+ * binding for this tenant.
+ *
+ * We deliberately do *not* expand to digits-only (`<digits>`) or the
+ * Baileys device-suffix JID (`<digits>:0@s.whatsapp.net`): neither has
+ * been observed as a persisted binding. Extend here if one ever is.
+ */
+export function expandWhatsAppOutboundChatJidCandidates(value: unknown): string[] {
+  const raw = readNonEmptyString(value);
+  if (!raw) {
+    return [];
+  }
+  const withoutPrefix = raw.replace(/^whatsapp:/i, "").trim();
+  if (!withoutPrefix) {
+    return [];
+  }
+  if (withoutPrefix.includes("@")) {
+    return [withoutPrefix];
+  }
+  const digits = withoutPrefix.replace(/[^\d]/g, "");
+  if (!digits) {
+    return [];
+  }
+  return withoutPrefix.startsWith("+")
+    ? [`+${digits}`, `${digits}@s.whatsapp.net`]
+    : [`${digits}@s.whatsapp.net`, `+${digits}`];
+}
+
 export function listWhatsAppOutboundRouteKeys(params: {
   requestedTo?: unknown;
   accountIds: Array<string | null | undefined>;
   rawSend?: Record<string, unknown> | null;
 }): string[] {
-  const outerChatJid = parseWhatsAppOutboundChatJid(params.requestedTo);
-  const innerChatJid =
-    parseWhatsAppOutboundChatJid(params.rawSend?.to) ??
-    parseWhatsAppOutboundChatJid(params.rawSend?.chatJid);
-  if (outerChatJid && innerChatJid && outerChatJid !== innerChatJid) {
+  const outerCandidates = expandWhatsAppOutboundChatJidCandidates(params.requestedTo);
+  const innerRaw = params.rawSend?.to ?? params.rawSend?.chatJid;
+  const innerCandidates = expandWhatsAppOutboundChatJidCandidates(innerRaw);
+
+  // Cross-field consistency: if both outer (`to`) and inner (`raw.to`/`raw.chatJid`)
+  // are provided, their candidate sets must overlap — otherwise the caller asked
+  // for two different peers and we refuse to guess.
+  let chatJidCandidates: string[];
+  if (outerCandidates.length > 0 && innerCandidates.length > 0) {
+    const innerSet = new Set(innerCandidates);
+    const intersection = outerCandidates.filter((c) => innerSet.has(c));
+    if (intersection.length === 0) {
+      return [];
+    }
+    chatJidCandidates = intersection;
+  } else {
+    chatJidCandidates = outerCandidates.length > 0 ? outerCandidates : innerCandidates;
+  }
+  if (chatJidCandidates.length === 0) {
     return [];
   }
-  const chatJid = outerChatJid;
-  if (!chatJid) {
-    return [];
+  const accountIds = uniqueRouteKeys(params.accountIds);
+  const routeKeys: Array<string | null> = [];
+  for (const accountId of accountIds) {
+    for (const chatJid of chatJidCandidates) {
+      routeKeys.push(buildWhatsAppRouteKey(chatJid, accountId));
+    }
   }
-  return uniqueRouteKeys(params.accountIds).map((accountId) =>
-    buildWhatsAppRouteKey(chatJid, accountId),
-  );
+  return uniqueRouteKeys(routeKeys);
 }

--- a/mux-server/test/server.outbound-routing.test.ts
+++ b/mux-server/test/server.outbound-routing.test.ts
@@ -2924,4 +2924,123 @@ describe("mux server", () => {
       error: "whatsapp send failed",
     });
   });
+
+  // Regression suite: route-key candidate expansion
+  //
+  // Bindings are observed in production as E164 bare (`+15550001111`) — the
+  // shape the current bridge emits for DMs — and as the canonical
+  // `<digits>@s.whatsapp.net` JID that the historical lookup always
+  // synthesized and that the rest of this file uses as fixture. The outbound
+  // route-key lookup must resolve an outbound `to` to either form without
+  // returning `403 route not bound` (the bug that left hangyin@phala.network's
+  // `/status` reply stuck in the delivery queue).
+  //
+  // 502 "whatsapp send failed" in these tests means the route lookup matched
+  // — the subsequent bridge send is a stub that always fails. 403 would mean
+  // the route lookup missed.
+
+  test("whatsapp outbound matches E164-bare binding when the caller provides E164 `to`", async () => {
+    const server = await h.startServer({
+      tenantsJson: JSON.stringify([{ id: "tenant-a", name: "Tenant A", apiKey: "tenant-a-key" }]),
+      pairingCodesJson: JSON.stringify([
+        {
+          code: "PAIR-WA-E164-BARE",
+          channel: "whatsapp",
+          // Binding stored as E164 bare — the historical chatJid shape that
+          // silently broke outbound routing.
+          routeKey: "whatsapp:default:chat:+15550001111",
+          scope: "chat",
+        },
+      ]),
+    });
+
+    expect(
+      (
+        await h.claimPairing({
+          port: server.port,
+          apiKey: "tenant-a-key",
+          code: "PAIR-WA-E164-BARE",
+          sessionKey: "agent:main:whatsapp:direct:+15550001111",
+        })
+      ).status,
+    ).toBe(200);
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/mux/outbound/send`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer tenant-a-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: "whatsapp",
+        sessionKey: "agent:main:main",
+        to: "whatsapp:+15550001111",
+        raw: {
+          whatsapp: {
+            send: {
+              text: "hello e164-bare",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: "whatsapp send failed",
+    });
+  });
+
+  test("whatsapp outbound still matches canonical `<digits>@s.whatsapp.net` binding (regression floor)", async () => {
+    const server = await h.startServer({
+      tenantsJson: JSON.stringify([{ id: "tenant-a", name: "Tenant A", apiKey: "tenant-a-key" }]),
+      pairingCodesJson: JSON.stringify([
+        {
+          code: "PAIR-WA-CANONICAL-E164",
+          channel: "whatsapp",
+          routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+          scope: "chat",
+        },
+      ]),
+    });
+
+    expect(
+      (
+        await h.claimPairing({
+          port: server.port,
+          apiKey: "tenant-a-key",
+          code: "PAIR-WA-CANONICAL-E164",
+          sessionKey: "agent:main:whatsapp:direct:+15550001111",
+        })
+      ).status,
+    ).toBe(200);
+
+    // Caller sends E164 `to` — must still resolve to the canonical binding.
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/mux/outbound/send`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer tenant-a-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: "whatsapp",
+        sessionKey: "agent:main:main",
+        to: "whatsapp:+15550001111",
+        raw: {
+          whatsapp: {
+            send: {
+              text: "hello canonical via e164",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: "whatsapp send failed",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a silent \`403 route not bound\` on WhatsApp mux outbound for tenants whose binding chatJid was stored in E164-bare form (`+<digits>`) rather than the canonical `<digits>@s.whatsapp.net`.

Discovered while debugging hangyin@phala.network's deployment: inbound `/status` reached the agent and the agent rendered the reply, but the outbound sat failing in openclaw's `/data/openclaw/delivery-queue` with `mux outbound failed (403): route not bound` on every retry.

## Root cause

`listWhatsAppOutboundRouteKeys` called `parseWhatsAppOutboundChatJid` to produce **one** canonical chatJid. That function strips `+` from E164 inputs and appends `@s.whatsapp.net`, so every outbound got looked up at `<digits>@s.whatsapp.net`. But the inbound path creates bindings directly from `message.chatId` emitted by the WhatsApp bridge, which has been observed in production as **either**:

| chatJid form | Status with old lookup |
|---|---|
| `<digits>@s.whatsapp.net` (canonical JID) | ✅ matches |
| `+<digits>` (E164 bare — current bridge for DMs) | ❌ miss |

Inbound forwarding worked because that path builds the routeKey from the same raw `chatId`. Outbound failed because the canonicalization doesn't round-trip.

## Fix

Add `expandWhatsAppOutboundChatJidCandidates`, which returns both forms for a bare-number input (input shape first), and passes through unchanged for fully-qualified JID / group / LID inputs. `listWhatsAppOutboundRouteKeys` builds routeKeys from each `candidate × accountId`, and the existing first-match in `resolveRouteKeyByTarget` picks whichever routeKey has an active binding.

Deliberately **not** expanded: digits-only (`<digits>`) and Baileys device-suffix (`<digits>:0@s.whatsapp.net`). No evidence either is ever persisted as a binding; extend here if one surfaces.

The change is **purely additive**:
- The original canonical `<digits>@s.whatsapp.net` remains a candidate for non-`+` inputs, so bindings that resolved before still resolve on the same candidate.
- Candidate expansion is scoped by `(tenantId, channel)` via `stmtSelectActiveBindingByTenantAndRoute` and cannot cross-route between tenants.
- `parseWhatsAppOutboundChatJid` is unchanged as a single-string helper; `listWhatsAppOutboundRouteKeys`'s rawSend cross-field consistency check intersects the outer/inner candidate sets, preserving the "different peers" rejection path.

## Tests

`test/server.outbound-routing.test.ts` — two new regression cases (each drives the binding through the real pairing path, then sends an outbound with `to: "whatsapp:+15550001111"` to prove the candidate expansion resolves it to a 502 "whatsapp send failed" — i.e. route matched, stub bridge send failed — instead of 403):

1. `whatsapp outbound matches E164-bare binding when the caller provides E164 to` — the hangyin case.
2. `whatsapp outbound still matches canonical <digits>@s.whatsapp.net binding (regression floor)`.

Verification:
- `pnpm test -- test/server.outbound-routing.test.ts` — 41/41 pass (39 before, added 2).
- `pnpm test` — 97/97 pass across the full mux-server suite.

## Rollout

Pairs with openclaw PR #107 (`whatsapp: preserve raw mux inbound to for non-LID targets`). Neither change alone fixes the hangyin case — the openclaw PR stops rewriting the value, and this PR teaches the mux-server to accept E164-bare bindings. Deploy as `test-whatsapp-outbound-expansion-<sha>` pre-release on prod9, validate against hangyin's `/status` in WhatsApp, then cut the formal mux-server release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)