### PR TITLE
whatsapp: resolve LID at bridge boundary; preserve LID through targeting layer

### DIFF
--- a/src/gateway/mux-http.test.ts
+++ b/src/gateway/mux-http.test.ts
@@ -1085,6 +1085,12 @@ describe("handleMuxInboundHttpRequest", () => {
       },
     },
     {
+      // Regression: a LID inbound target must pass through to originatingTo
+      // verbatim. The mux-server's binding is keyed by the same LID that
+      // shows up here; mangling it to sender E164 (as `ba609a572e` did)
+      // breaks the outbound route-key lookup end-to-end. See the mux-side
+      // heal logic that rewrites LID route_keys to canonical form — after
+      // that heal, this LID still resolves via the binding's alias entry.
       name: "whatsapp dm lid target",
       body: {
         channel: "whatsapp",
@@ -1099,7 +1105,7 @@ describe("handleMuxInboundHttpRequest", () => {
         sessionKey: "agent:main:main",
         surface: "mux",
         originatingChannel: "whatsapp",
-        originatingTo: "whatsapp:+15550001111",
+        originatingTo: "whatsapp:258862678593671@lid",
         messageThreadId: undefined,
       },
     },

--- a/src/gateway/mux-http.ts
+++ b/src/gateway/mux-http.ts
@@ -339,19 +339,6 @@ function resolveMuxInboundOriginatingTo(params: {
     }
     return peer.kind === "direct" ? `user:${peer.id}` : `channel:${peer.id}`;
   }
-  if (params.channel === "whatsapp") {
-    // Preserve the raw mux inbound `to` so downstream route-key lookup on the
-    // mux-server still matches the binding registered from the exact same
-    // JID (including the optional Baileys device suffix, e.g. `:0`). LID
-    // targets have no phone number and cannot be replied to directly, so fall
-    // back to the sender there.
-    const rawTo = readMuxNonEmptyString(params.payload.to);
-    if (rawTo && !/@lid\b/i.test(rawTo)) {
-      return rawTo;
-    }
-    const peer = resolveWhatsAppInboundPeer({ payload: params.payload });
-    return peer ? `whatsapp:${peer.id}` : null;
-  }
   return readMuxNonEmptyString(params.payload.to) ?? null;
 }
 

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -369,6 +369,23 @@ export async function monitorWebInbox(options: {
       },
       "inbound message",
     );
+    // Canonical chatId for DMs: prefer the resolved E164 JID form
+    // (`<digits>@s.whatsapp.net`) so downstream consumers never see `@lid`
+    // peers. `inbound.from` is already E164 for DMs (resolved via
+    // `resolveJidToE164` → Baileys `lidMapping` when needed). Falling back
+    // to the raw `remoteJid` if resolution produced something unexpected
+    // keeps the pipeline moving without silent data loss. Groups preserve
+    // their `@g.us` JID — group JIDs have no LID form.
+    const canonicalChatId = (() => {
+      if (inbound.group) {
+        return inbound.remoteJid;
+      }
+      const e164 = inbound.from;
+      if (typeof e164 === "string" && /^\+\d+$/.test(e164)) {
+        return `${e164.slice(1)}@s.whatsapp.net`;
+      }
+      return inbound.remoteJid;
+    })();
     const inboundMessage: WebInboundMessage = {
       id: inbound.id,
       from: inbound.from,
@@ -379,7 +396,10 @@ export async function monitorWebInbox(options: {
       pushName: senderName,
       timestamp,
       chatType: inbound.group ? "group" : "direct",
-      chatId: inbound.remoteJid,
+      chatId: canonicalChatId,
+      // Expose the original remoteJid for mux-server's legacy-binding
+      // fallback lookup. Same value as chatId for non-LID peers.
+      remoteJidRaw: inbound.remoteJid,
       senderJid: inbound.participantJid,
       senderE164: inbound.senderE164 ?? undefined,
       senderName,

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -17,7 +17,32 @@ export type WebInboundMessage = {
   pushName?: string;
   timestamp?: number;
   chatType: "direct" | "group";
+  /**
+   * Canonical chat identifier used by the rest of the pipeline.
+   *
+   * For DMs, this is the resolved canonical JID form `<e164-digits>@s.whatsapp.net`
+   * derived from `inbound.from` (which the bridge already resolves via
+   * `resolveJidToE164`, consulting the Baileys `lidMapping` when the WhatsApp
+   * side addressed the peer by LID). When resolution is unavailable (stale
+   * lidMapping, unknown peer) we fall back to the raw `remoteJid` so the
+   * downstream pipeline still carries *something* to route on.
+   *
+   * For groups, this is the `@g.us` group JID — groups never have a LID form.
+   *
+   * The raw unresolved JID is separately exposed as `remoteJidRaw` so
+   * consumers that still need the original addressing form (e.g. the
+   * mux-server's legacy-binding fallback lookup) can see it explicitly
+   * without mucking with `chatId`.
+   */
   chatId: string;
+  /**
+   * The raw `remoteJid` emitted by Baileys, before any LID→E164 resolution.
+   * Equals `chatId` for any peer WhatsApp already addresses by phone JID or
+   * group JID; for LID peers this is the `<lid>@lid` form. Consumers
+   * **should prefer `chatId`** — this field is for legacy-binding fallback
+   * paths only.
+   */
+  remoteJidRaw?: string;
   senderJid?: string;
   senderE164?: string;
   senderName?: string;

--- a/src/whatsapp/normalize.test.ts
+++ b/src/whatsapp/normalize.test.ts
@@ -23,9 +23,18 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("41796666864@s.whatsapp.net")).toBe("+41796666864");
   });
 
-  it("normalizes LID JIDs to E.164", () => {
-    expect(normalizeWhatsAppTarget("123456789@lid")).toBe("+123456789");
-    expect(normalizeWhatsAppTarget("123456789@LID")).toBe("+123456789");
+  it("preserves LID JIDs verbatim (they have no phone-number representation)", () => {
+    // LIDs are opaque WhatsApp Linked IDs — the digits are NOT a phone
+    // number. Previously we ran them through normalizeE164, producing a
+    // bogus fake E.164 that broke allowFrom checks and mux route lookups.
+    expect(normalizeWhatsAppTarget("123456789@lid")).toBe("123456789@lid");
+    expect(normalizeWhatsAppTarget("123456789@LID")).toBe("123456789@LID");
+    // Baileys device-suffix LIDs (`<lid>:0@lid`) round-trip too.
+    expect(normalizeWhatsAppTarget("258862678593671:0@lid")).toBe("258862678593671:0@lid");
+    // Hosted LID variant.
+    expect(normalizeWhatsAppTarget("987654321@hosted.lid")).toBe("987654321@hosted.lid");
+    // `whatsapp:` prefix is still stripped, but the LID body is preserved.
+    expect(normalizeWhatsAppTarget("whatsapp:123456789@lid")).toBe("123456789@lid");
   });
 
   it("rejects invalid targets", () => {
@@ -51,6 +60,10 @@ describe("isWhatsAppUserTarget", () => {
     expect(isWhatsAppUserTarget("1234567890@s.whatsapp.net")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@lid")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@LID")).toBe(true);
+    // Baileys device-suffix LID (colon *before* @).
+    expect(isWhatsAppUserTarget("123456789:0@lid")).toBe(true);
+    expect(isWhatsAppUserTarget("123456789@hosted.lid")).toBe(true);
+    // Colon after @ is not a valid WhatsApp JID suffix.
     expect(isWhatsAppUserTarget("123@lid:0")).toBe(false);
     expect(isWhatsAppUserTarget("abc@s.whatsapp.net")).toBe(false);
     expect(isWhatsAppUserTarget("123456789-987654321@g.us")).toBe(false);

--- a/src/whatsapp/normalize.ts
+++ b/src/whatsapp/normalize.ts
@@ -1,7 +1,9 @@
 import { normalizeE164 } from "../utils.js";
 
 const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
-const WHATSAPP_LID_RE = /^(\d+)@lid$/i;
+// Baileys emits LIDs both plain (`123@lid`) and with a device suffix
+// (`123:0@lid`), and occasionally the `@hosted.lid` variant. Accept all.
+const WHATSAPP_LID_RE = /^(\d+)(?::\d+)?@(?:lid|hosted\.lid)$/i;
 
 function stripWhatsAppTargetPrefixes(value: string): string {
   let candidate = value.trim();
@@ -60,6 +62,15 @@ export function normalizeWhatsAppTarget(value: string): string | null {
   if (isWhatsAppGroupJid(candidate)) {
     const localPart = candidate.slice(0, candidate.length - "@g.us".length);
     return `${localPart}@g.us`;
+  }
+  // LID targets (e.g. "123456@lid") don't carry a phone number — the
+  // digits before `@lid` are an opaque WhatsApp Linked ID. Preserve the
+  // LID verbatim so downstream routing uses it as-is. Historically this
+  // branch fell through to `normalizeE164(extractUserJidPhone(...))`,
+  // which re-painted the LID digits as a bogus E164 (e.g. `+258862...`)
+  // and broke both allowFrom checks and mux-server route lookups.
+  if (WHATSAPP_LID_RE.test(candidate)) {
+    return candidate;
   }
   // Handle user JIDs (e.g. "41796666864:0@s.whatsapp.net")
   if (isWhatsAppUserTarget(candidate)) {

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -200,6 +200,48 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
   });
 
+  describe("LID target handling", () => {
+    // LID peers are gated upstream (mux-server's binding claim is the
+    // access-control point). An E.164 allowFrom list cannot validate LIDs
+    // because their digits are opaque, not phone numbers. Trust model
+    // matches groups: if normalize returns a LID, pass through.
+    it("passes LID target through regardless of allowList", () => {
+      const LID = "258862678593671@lid";
+      // normalizeWhatsAppTarget is called once per allowFrom entry and
+      // once for the `to` — order: allowFrom entries first, `to` last.
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce("+15105989468") // for allowFrom[0]
+        .mockReturnValueOnce(LID); // for to
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+      expectResolutionOk(
+        {
+          to: LID,
+          allowFrom: ["+15105989468"],
+          mode: "implicit",
+        },
+        LID,
+      );
+    });
+
+    it("passes device-suffix LID target through regardless of allowList", () => {
+      const LID = "258862678593671:0@lid";
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce("+15105989468")
+        .mockReturnValueOnce(LID);
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+      expectResolutionOk({ to: LID, allowFrom: ["+15105989468"], mode: undefined }, LID);
+    });
+
+    it("passes hosted LID target through regardless of allowList", () => {
+      const LID = "987654321@hosted.lid";
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce("+15105989468")
+        .mockReturnValueOnce(LID);
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+      expectResolutionOk({ to: LID, allowFrom: ["+15105989468"], mode: "heartbeat" }, LID);
+    });
+  });
+
   describe("whitespace handling", () => {
     it("trims whitespace from to parameter", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET);

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -1,6 +1,15 @@
 import { missingTargetError } from "../infra/outbound/target-errors.js";
 import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize.js";
 
+// LID (Linked ID) targets are opaque privacy identifiers — the digits
+// carry no phone-number information, so they cannot appear in an
+// allowFrom list that's expressed as E.164. When outbound delivery
+// targets a LID, the mux-server (not this agent) is the source of truth
+// for who may be messaged: a LID only ever reaches us via an already
+// claimed mux binding, which itself gated inbound. Skipping allowFrom
+// for LID here is the same trust posture we apply to group JIDs.
+const WHATSAPP_LID_TARGET_RE = /@(?:lid|hosted\.lid)$/i;
+
 export type WhatsAppOutboundTargetResolution =
   | { ok: true; to: string }
   | { ok: false; error: Error };
@@ -29,6 +38,14 @@ export function resolveWhatsAppOutboundTarget(params: {
       };
     }
     if (isWhatsAppGroupJid(normalizedTo)) {
+      return { ok: true, to: normalizedTo };
+    }
+    // LID targets pass the same trust gate as groups — mux-server already
+    // gated which LIDs can reach this agent at pairing/binding time, so
+    // re-gating via an E.164 allowFrom list here would be incorrect
+    // (LIDs have no E.164 representation) and blocks legitimate replies
+    // and cron deliveries to paired LID peers.
+    if (WHATSAPP_LID_TARGET_RE.test(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
     // Enforce allowFrom for all direct-message send modes (including explicit).


### PR DESCRIPTION
## Summary

Kills the LID ↔ targeting-layer impedance mismatch at the source. WhatsApp LID (Linked ID) peers now flow through openclaw's pipeline as canonical `<digits>@s.whatsapp.net` JIDs — the same shape native WhatsApp deployments have always used — so `normalizeWhatsAppTarget`, `resolveWhatsAppOutboundTarget`, sessions, and cron jobs never need LID-specific code paths in the happy path.

Completes the fallback from `ba609a572e` (which introduced a LID→sender-E164 rewrite that we've spent two PRs — #107, #108 — partially papering over) by fully reverting it. The LID test case's expected `originatingTo` flips back to the raw LID, which is what the mux-server's binding lookup matches against.

## Two-layer fix

**Bridge boundary (`src/web/inbound/monitor.ts`)**: emit a canonical chatId from the already-resolved `inbound.from` (the bridge already runs `resolveJidToE164` → Baileys `lidMapping`). `WebInboundMessage` grows a `remoteJidRaw` field so mux-server has the unresolved LID to use for its legacy-binding fallback lookup.

**Defensive targeting layer**: any persisted LID state (`sessions.json` `lastTo`, `cron/jobs.json` `delivery.to`, anything a mux-server envelope still delivers during the transition) must not blow up:

- `src/whatsapp/normalize.ts` — `normalizeWhatsAppTarget` now preserves `@lid` / `@hosted.lid` / Baileys `:0@lid` inputs verbatim. The old behavior ran LID digits through `normalizeE164` and produced a bogus fake E.164 (`+258862678593671`) that broke both allowFrom checks and the mux-server's route-key lookup. Regex widened to cover Baileys and hosted variants.
- `src/whatsapp/resolve-outbound-target.ts` — LID targets bypass the E.164 `allowFrom` check, same trust posture as group JIDs. An E.164 list fundamentally cannot validate LIDs, and the mux-server already access-gated the binding upstream.

## Paired change

**Ships with a companion mux-server PR** that adds a self-migrating binding heal: canonical lookup first, `remoteJidRaw` fallback, rewrite `bindings.route_key` to canonical and retain the legacy LID routeKey as an alias. Needed so existing LID-keyed bindings keep serving outbounds whose `to` was frozen in LID form at cron-creation time. Neither PR is usable without the other — merge as a pair, cut phala.18 together.

## Tests

- `src/whatsapp/normalize.test.ts` — LID passthrough for plain `@lid`, Baileys device-suffix `:0@lid`, `@hosted.lid`, and `whatsapp:`-prefixed inputs. Widened `isWhatsAppUserTarget` coverage for the new regex.
- `src/whatsapp/resolve-outbound-target.test.ts` — three new cases covering LID-target allowFrom bypass for implicit / undefined / heartbeat modes, all with an E.164 allowFrom list that would otherwise reject.
- `src/gateway/mux-http.test.ts` — `"whatsapp dm lid target"` expected `originatingTo` flipped back to the raw LID so the inbound → outbound round-trip preserves what the mux-server's target-first lookup needs.

Verification:
- `npx vitest run src/whatsapp/normalize.test.ts src/whatsapp/resolve-outbound-target.test.ts src/gateway/mux-http.test.ts` — **73/73 pass**.
- Broader suite (`src/gateway/`, `src/whatsapp/`, `src/auto-reply/reply/session-delivery.test.ts`): same pre-existing 3-file / 10-test failure pattern that exists on `phala-2026.3.13` HEAD without my changes (auth / symlink / client-callsites guard tests, none WhatsApp-related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)