### PR TITLE
mux-server/whatsapp: self-heal legacy LID bindings with route-key aliasing

### DIFF
--- a/mux-server/src/channels/whatsapp/inbound.ts
+++ b/mux-server/src/channels/whatsapp/inbound.ts
@@ -7,7 +7,7 @@ import type { ClaimResult, StyledNotice, TenantInboundTarget } from "../../domai
 import { errorString, readNonEmptyString } from "../../domain/values.js";
 import { buildWhatsAppInboundEnvelope } from "../../mux-envelope.js";
 import { createInboundTraceId } from "../../observability/tracing.js";
-import { deriveWhatsAppSessionKey } from "../../routing/keys.js";
+import { buildWhatsAppRouteKey, deriveWhatsAppSessionKey } from "../../routing/keys.js";
 import {
   classifyWhatsAppInboundDeliveryError,
   resolveWhatsAppInboundQueueRetryState,
@@ -33,7 +33,16 @@ type WebInboundMessage = {
   body: string;
   timestamp?: number;
   chatType: "direct" | "group";
+  // The canonical chatId emitted by the bridge -- `<digits>@s.whatsapp.net`
+  // for DMs (resolved via lidMapping when the WhatsApp side used a LID),
+  // `<jid>@g.us` for groups.
   chatId: string;
+  // The raw `remoteJid` from Baileys before LID resolution. Equals `chatId`
+  // for non-LID peers; for LID peers this is the `<lid>@lid` form. Used
+  // for the one-time binding heal that rewrites legacy LID-keyed bindings
+  // to their canonical form while keeping the LID as an alias so frozen
+  // `delivery.to` targets on existing crons still resolve.
+  remoteJidRaw?: string;
   senderJid?: string;
   senderE164?: string;
   senderName?: string;
@@ -164,7 +173,14 @@ export function createWhatsAppInboundRuntime(deps: {
     | "stmtDeferWhatsAppInboundQueueById"
     | "stmtSelectSessionKeyByBinding"
     | "stmtUpsertSessionRoute"
+    | "stmtMigrateBindingRouteKeyWithAlias"
   >;
+  writeAuditLog: (
+    tenantId: string,
+    eventType: string,
+    payload: Record<string, unknown>,
+    createdAtMs: number,
+  ) => void;
   metrics: Metrics;
   parseBotControlCommand: (input: string) => BotControlCommand | null;
   handleWhatsAppBotControlCommand: (params: {
@@ -233,6 +249,7 @@ export function createWhatsAppInboundRuntime(deps: {
           : undefined,
       chatType: message.chatType === "group" ? "group" : "direct",
       chatId: readNonEmptyString(message.chatId) ?? readNonEmptyString(message.from) ?? "",
+      remoteJidRaw: readNonEmptyString(message.remoteJidRaw) ?? undefined,
       senderJid: readNonEmptyString(message.senderJid) ?? undefined,
       senderE164: readNonEmptyString(message.senderE164) ?? undefined,
       senderName: readNonEmptyString(message.senderName) ?? undefined,
@@ -346,6 +363,7 @@ export function createWhatsAppInboundRuntime(deps: {
     if (!chatJid) {
       return;
     }
+    const remoteJidRaw = readNonEmptyString(message.remoteJidRaw);
     const accountId = readNonEmptyString(message.accountId) ?? deps.config.whatsappAccountId;
     const chatType = message.chatType === "group" ? "group" : "direct";
     const directPeerId =
@@ -353,10 +371,63 @@ export function createWhatsAppInboundRuntime(deps: {
         ? (readNonEmptyString(message.senderE164) ?? readNonEmptyString(message.from) ?? undefined)
         : undefined;
     const body = typeof message.body === "string" ? message.body : "";
-    const binding = deps.resolveWhatsAppBindingForIncoming({
+    // Canonical lookup first. Covers new users and previously-healed
+    // LID bindings (where the LID now lives in `previous_route_keys`).
+    let binding = deps.resolveWhatsAppBindingForIncoming({
       chatJid,
       accountId,
     });
+    // Legacy LID fallback: if the canonical chatJid missed AND the bridge
+    // gave us a raw LID that differs from the canonical form, try looking
+    // the binding up under its original LID routeKey. On a hit, heal the
+    // binding -- rewrite `route_key` to the canonical form and push the
+    // LID into `previous_route_keys` so it keeps resolving for anyone
+    // still holding the LID (e.g. cron `delivery.to`).
+    if (
+      !binding &&
+      remoteJidRaw &&
+      remoteJidRaw !== chatJid &&
+      /@(?:lid|hosted\.lid)$/i.test(remoteJidRaw)
+    ) {
+      const legacyBinding = deps.resolveWhatsAppBindingForIncoming({
+        chatJid: remoteJidRaw,
+        accountId,
+      });
+      if (legacyBinding) {
+        const canonicalRouteKey = buildWhatsAppRouteKey(chatJid, accountId);
+        const legacyRouteKey = buildWhatsAppRouteKey(remoteJidRaw, accountId);
+        try {
+          deps.db.stmtMigrateBindingRouteKeyWithAlias.run(
+            canonicalRouteKey,
+            legacyRouteKey,
+            Date.now(),
+            legacyBinding.bindingId,
+            legacyBinding.tenantId,
+          );
+          deps.writeAuditLog(
+            legacyBinding.tenantId,
+            "whatsapp_binding_healed_from_lid",
+            {
+              bindingId: legacyBinding.bindingId,
+              legacyRouteKey,
+              canonicalRouteKey,
+            },
+            Date.now(),
+          );
+        } catch (error) {
+          deps.log({
+            type: "whatsapp_binding_heal_error",
+            bindingId: legacyBinding.bindingId,
+            error: String(error),
+          });
+        }
+        binding = {
+          tenantId: legacyBinding.tenantId,
+          bindingId: legacyBinding.bindingId,
+          routeKey: canonicalRouteKey,
+        };
+      }
+    }
     const botControlCommand = deps.parseBotControlCommand(body);
     if (botControlCommand) {
       try {

--- a/mux-server/src/db/schema.ts
+++ b/mux-server/src/db/schema.ts
@@ -49,6 +49,13 @@ export function initializeDatabase(database: DatabaseSync) {
       channel TEXT NOT NULL,
       scope TEXT NOT NULL,
       route_key TEXT NOT NULL,
+      -- JSON array of alternate routeKeys that also resolve to this binding.
+      -- Populated when a binding is healed from a legacy chatJid form (e.g.
+      -- <lid>@lid) to a canonical one (<digits>@s.whatsapp.net); the
+      -- legacy form is kept here so outbound lookups whose target was frozen
+      -- under the old form -- mainly cron delivery.to baked in at job
+      -- creation -- still resolve to this binding.
+      previous_route_keys TEXT NOT NULL DEFAULT '[]',
       status TEXT NOT NULL DEFAULT 'active',
       created_at_ms INTEGER NOT NULL,
       updated_at_ms INTEGER NOT NULL
@@ -122,6 +129,15 @@ export function initializeDatabase(database: DatabaseSync) {
   ensureTenantInboundTargetColumns(database);
   ensurePairingTokenColumns(database);
   ensureWhatsAppInboundQueueColumns(database);
+  ensureBindingsRouteKeyAliasColumn(database);
+}
+
+export function ensureBindingsRouteKeyAliasColumn(database: DatabaseSync) {
+  const rows = database.prepare("PRAGMA table_info(bindings)").all() as Array<{ name?: unknown }>;
+  const columnNames = new Set(rows.map((row) => (typeof row.name === "string" ? row.name : "")));
+  if (!columnNames.has("previous_route_keys")) {
+    database.exec("ALTER TABLE bindings ADD COLUMN previous_route_keys TEXT NOT NULL DEFAULT '[]'");
+  }
 }
 
 export function ensureTenantInboundTargetColumns(database: DatabaseSync) {

--- a/mux-server/src/db/statements.ts
+++ b/mux-server/src/db/statements.ts
@@ -286,10 +286,25 @@ export function createPreparedStatements(db: DatabaseSync) {
     LIMIT 1
   `);
 
+  // The `OR EXISTS (... json_each(previous_route_keys) ...)` clause lets a
+  // binding that has been healed from a legacy chatJid form (e.g. `@lid`)
+  // to the canonical form (`@s.whatsapp.net`) still resolve lookups whose
+  // caller is holding the legacy routeKey — this is how we keep existing
+  // cron `delivery.to` entries (frozen at cron-creation time) working
+  // without a bulk openclaw-side migration.
+  //
+  // Callers pass the search routeKey twice: once for the direct match and
+  // once for the alias-existence check. The `json_each` extension is part
+  // of the SQLite JSON1 module, built into `node:sqlite`.
   const stmtSelectActiveBindingByRouteKey = db.prepare(`
     SELECT tenant_id, binding_id
     FROM bindings
-    WHERE channel = ? AND route_key = ? AND status = 'active'
+    WHERE channel = ?
+      AND (
+        route_key = ?
+        OR EXISTS (SELECT 1 FROM json_each(previous_route_keys) WHERE value = ?)
+      )
+      AND status = 'active'
     ORDER BY updated_at_ms DESC
     LIMIT 1
   `);
@@ -297,7 +312,12 @@ export function createPreparedStatements(db: DatabaseSync) {
   const stmtSelectLiveBindingByRouteKey = db.prepare(`
     SELECT tenant_id, binding_id, status
     FROM bindings
-    WHERE channel = ? AND route_key = ? AND status IN ('active', 'pending')
+    WHERE channel = ?
+      AND (
+        route_key = ?
+        OR EXISTS (SELECT 1 FROM json_each(previous_route_keys) WHERE value = ?)
+      )
+      AND status IN ('active', 'pending')
     ORDER BY updated_at_ms DESC
     LIMIT 1
   `);
@@ -305,9 +325,32 @@ export function createPreparedStatements(db: DatabaseSync) {
   const stmtSelectActiveBindingByTenantAndRoute = db.prepare(`
     SELECT binding_id, status
     FROM bindings
-    WHERE tenant_id = ? AND channel = ? AND route_key = ? AND status IN ('active', 'pending')
+    WHERE tenant_id = ?
+      AND channel = ?
+      AND (
+        route_key = ?
+        OR EXISTS (SELECT 1 FROM json_each(previous_route_keys) WHERE value = ?)
+      )
+      AND status IN ('active', 'pending')
     ORDER BY updated_at_ms DESC
     LIMIT 1
+  `);
+
+  // Healing statement: rewrite a binding's route_key to the canonical form
+  // and push the prior (legacy) routeKey into `previous_route_keys`. Called
+  // once per binding, when an inbound arrives at the canonical chatJid for
+  // the first time and the canonical lookup missed but the legacy-form
+  // lookup hit.
+  const stmtMigrateBindingRouteKeyWithAlias = db.prepare(`
+    UPDATE bindings
+    SET route_key = ?,
+        previous_route_keys = json_insert(
+          previous_route_keys,
+          '$[#]',
+          ?
+        ),
+        updated_at_ms = ?
+    WHERE binding_id = ? AND tenant_id = ?
   `);
 
   const stmtListActiveDiscordBindings = db.prepare(`
@@ -443,6 +486,7 @@ export function createPreparedStatements(db: DatabaseSync) {
     stmtSelectActiveBindingByRouteKey,
     stmtSelectLiveBindingByRouteKey,
     stmtSelectActiveBindingByTenantAndRoute,
+    stmtMigrateBindingRouteKeyWithAlias,
     stmtListActiveDiscordBindings,
     stmtSelectTelegramOffset,
     stmtUpsertTelegramOffset,

--- a/mux-server/src/domain/binding-helpers.ts
+++ b/mux-server/src/domain/binding-helpers.ts
@@ -321,7 +321,7 @@ export function createBindingHelpers(deps: {
   function resolveIMessageBindingForIncoming(
     routeKey: string,
   ): { tenantId: string; bindingId: string; routeKey: string } | null {
-    const row = deps.db.stmtSelectActiveBindingByRouteKey.get("imessage", routeKey) as
+    const row = deps.db.stmtSelectActiveBindingByRouteKey.get("imessage", routeKey, routeKey) as
       | ActiveBindingLookupRow
       | undefined;
     if (!row?.tenant_id || !row?.binding_id) {
@@ -414,9 +414,11 @@ export function createBindingHelpers(deps: {
   ): { tenantId: string; bindingId: string; routeKey: string } | null {
     const topicRouteKey = topicId ? buildTelegramRouteKey(chatId, topicId) : null;
     if (topicRouteKey) {
-      const topicRow = deps.db.stmtSelectActiveBindingByRouteKey.get("telegram", topicRouteKey) as
-        | ActiveBindingLookupRow
-        | undefined;
+      const topicRow = deps.db.stmtSelectActiveBindingByRouteKey.get(
+        "telegram",
+        topicRouteKey,
+        topicRouteKey,
+      ) as ActiveBindingLookupRow | undefined;
       if (topicRow?.tenant_id && topicRow?.binding_id) {
         return {
           tenantId: String(topicRow.tenant_id),
@@ -427,9 +429,11 @@ export function createBindingHelpers(deps: {
     }
 
     const chatRouteKey = buildTelegramRouteKey(chatId);
-    const chatRow = deps.db.stmtSelectActiveBindingByRouteKey.get("telegram", chatRouteKey) as
-      | ActiveBindingLookupRow
-      | undefined;
+    const chatRow = deps.db.stmtSelectActiveBindingByRouteKey.get(
+      "telegram",
+      chatRouteKey,
+      chatRouteKey,
+    ) as ActiveBindingLookupRow | undefined;
     if (!chatRow?.tenant_id || !chatRow?.binding_id) {
       return null;
     }
@@ -445,7 +449,7 @@ export function createBindingHelpers(deps: {
     accountId: string;
   }): { tenantId: string; bindingId: string; routeKey: string } | null {
     const routeKey = buildWhatsAppRouteKey(params.chatJid, params.accountId);
-    const row = deps.db.stmtSelectActiveBindingByRouteKey.get("whatsapp", routeKey) as
+    const row = deps.db.stmtSelectActiveBindingByRouteKey.get("whatsapp", routeKey, routeKey) as
       | ActiveBindingLookupRow
       | undefined;
     if (!row?.tenant_id || !row?.binding_id) {

--- a/mux-server/src/pairing/service.ts
+++ b/mux-server/src/pairing/service.ts
@@ -232,6 +232,7 @@ export function createPairingService(deps: {
         tenantId,
         "telegram",
         boundRouteKey,
+        boundRouteKey,
       ) as ExistingBindingRow | undefined;
 
       if (existing?.binding_id && existing?.status === "active") {
@@ -387,6 +388,7 @@ export function createPairingService(deps: {
       const existing = deps.db.stmtSelectActiveBindingByTenantAndRoute.get(
         tenantId,
         "discord",
+        boundRouteKey,
         boundRouteKey,
       ) as ExistingBindingRow | undefined;
       if (existing?.status === "active") {
@@ -581,6 +583,7 @@ export function createPairingService(deps: {
         tenantId,
         "whatsapp",
         routeKey,
+        routeKey,
       ) as ExistingBindingRow | undefined;
 
       if (existing?.binding_id && existing?.status === "active") {
@@ -731,6 +734,7 @@ export function createPairingService(deps: {
       const existing = deps.db.stmtSelectActiveBindingByTenantAndRoute.get(
         tenantId,
         "imessage",
+        routeKey,
         routeKey,
       ) as ExistingBindingRow | undefined;
 

--- a/mux-server/src/routing/route-resolution.ts
+++ b/mux-server/src/routing/route-resolution.ts
@@ -74,11 +74,16 @@ export function createRouteResolutionHelpers(deps: {
       sessionKey: string,
     ) => Record<string, unknown> | undefined;
   };
+  // The statement binds the routeKey twice: once for the direct
+  // `route_key = ?` match and once for the `previous_route_keys` alias
+  // check. See `stmtSelectActiveBindingByTenantAndRoute` in
+  // `src/db/statements.ts`.
   stmtSelectActiveBindingByTenantAndRoute: {
     get: (
       tenantId: string,
       channel: "telegram" | "discord" | "whatsapp" | "imessage",
       routeKey: string,
+      routeKeyAlias: string,
     ) => Record<string, unknown> | undefined;
   };
   resolveDiscordChannelInfo: (channelId: string) => Promise<{
@@ -257,6 +262,7 @@ export function createRouteResolutionHelpers(deps: {
       const row = deps.stmtSelectActiveBindingByTenantAndRoute.get(
         params.tenantId,
         params.channel,
+        routeKey,
         routeKey,
       ) as ExistingBindingRow | undefined;
       if (!row?.binding_id || row.status !== "active") {

--- a/mux-server/src/server.ts
+++ b/mux-server/src/server.ts
@@ -358,7 +358,7 @@ function resolveLiveBindingByRouteKey(
   channel: string,
   routeKey: string,
 ): LiveBindingLookupRow | null {
-  const row = stmtSelectLiveBindingByRouteKey.get(channel, routeKey) as
+  const row = stmtSelectLiveBindingByRouteKey.get(channel, routeKey, routeKey) as
     | LiveBindingLookupRow
     | undefined;
   if (!row?.tenant_id || !row?.binding_id || !row?.status) {
@@ -725,6 +725,7 @@ const { runWhatsAppInboundLoop } = createWhatsAppInboundRuntime({
   loadWebRuntimeModules,
   log,
   db: stmts,
+  writeAuditLog,
   metrics,
   parseBotControlCommand,
   handleWhatsAppBotControlCommand,

--- a/mux-server/test/bindings.lid-alias.test.ts
+++ b/mux-server/test/bindings.lid-alias.test.ts
@@ -1,0 +1,289 @@
+import { DatabaseSync } from "node:sqlite";
+import { beforeEach, describe, expect, test } from "vitest";
+import { initializeDatabase } from "../src/db/schema.js";
+import { createPreparedStatements } from "../src/db/statements.js";
+
+// Regression tests for the WhatsApp LID-binding heal + alias resolution
+// pathway. The mux-server binds on the first inbound using whatever
+// `chatJid` the Baileys bridge emits; historically this was sometimes a
+// `<lid>@lid` form and the rest of the pipeline (cron `delivery.to`,
+// `persistedLastTo`) froze that LID into its state. Our bridge fix now
+// emits the canonical `<digits>@s.whatsapp.net` JID for DMs, but we can't
+// bulk-migrate agent-side state, so the mux-server must:
+//
+//   1. Heal legacy LID-keyed bindings in place on first inbound post-fix,
+//      preserving the LID in `previous_route_keys` as an alias.
+//   2. Resolve outbound lookups against both `route_key` AND any alias.
+//
+// These tests pin both behaviors with direct DB writes so they stay
+// pinned even when surface-level code moves around.
+
+function seedTenant(db: DatabaseSync, tenantId: string) {
+  db.prepare(
+    `INSERT INTO tenants (id, name, api_key_hash, status, created_at_ms, updated_at_ms)
+     VALUES (?, ?, ?, 'active', ?, ?)`,
+  ).run(tenantId, `Tenant ${tenantId}`, `key-${tenantId}`, Date.now(), Date.now());
+}
+
+function seedBinding(
+  db: DatabaseSync,
+  params: {
+    tenantId: string;
+    bindingId: string;
+    channel: string;
+    routeKey: string;
+    previousRouteKeys?: string[];
+    status?: string;
+    scope?: string;
+  },
+) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO bindings (
+       binding_id, tenant_id, channel, scope, route_key,
+       previous_route_keys, status, created_at_ms, updated_at_ms
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    params.bindingId,
+    params.tenantId,
+    params.channel,
+    params.scope ?? "chat",
+    params.routeKey,
+    JSON.stringify(params.previousRouteKeys ?? []),
+    params.status ?? "active",
+    now,
+    now,
+  );
+}
+
+describe("WhatsApp binding LID → canonical alias", () => {
+  let db: DatabaseSync;
+  let stmts: ReturnType<typeof createPreparedStatements>;
+
+  beforeEach(() => {
+    db = new DatabaseSync(":memory:");
+    initializeDatabase(db);
+    stmts = createPreparedStatements(db);
+  });
+
+  test("fresh schema starts with empty previous_route_keys default", () => {
+    seedTenant(db, "tenant-a");
+    const now = Date.now();
+    stmts.stmtInsertBinding.run(
+      "bind-1",
+      "tenant-a",
+      "whatsapp",
+      "chat",
+      "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      now,
+      now,
+    );
+    const row = db
+      .prepare("SELECT previous_route_keys FROM bindings WHERE binding_id = ?")
+      .get("bind-1") as { previous_route_keys?: unknown } | undefined;
+    expect(row?.previous_route_keys).toBe("[]");
+  });
+
+  test("stmtSelectActiveBindingByTenantAndRoute matches the direct route_key", () => {
+    seedTenant(db, "tenant-a");
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-1",
+      channel: "whatsapp",
+      routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+    });
+    const direct = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      "whatsapp:default:chat:15550001111@s.whatsapp.net",
+    ) as { binding_id?: unknown } | undefined;
+    expect(direct?.binding_id).toBe("bind-1");
+  });
+
+  test("stmtSelectActiveBindingByTenantAndRoute matches an alias in previous_route_keys", () => {
+    seedTenant(db, "tenant-a");
+    // This simulates the post-heal state: binding's `route_key` is the
+    // canonical form, and the legacy LID routeKey lives in the alias
+    // array. Outbound targets baked under the LID (e.g. existing cron
+    // `delivery.to`) must still resolve to this binding.
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-1",
+      channel: "whatsapp",
+      routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      previousRouteKeys: ["whatsapp:default:chat:258862678593671@lid"],
+    });
+
+    // Lookup via canonical routeKey: hits directly.
+    const viaCanonical = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      "whatsapp:default:chat:15550001111@s.whatsapp.net",
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaCanonical?.binding_id).toBe("bind-1");
+
+    // Lookup via LID alias: also hits.
+    const viaLid = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      "whatsapp:default:chat:258862678593671@lid",
+      "whatsapp:default:chat:258862678593671@lid",
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaLid?.binding_id).toBe("bind-1");
+  });
+
+  test("stmtSelectActiveBindingByRouteKey also checks aliases", () => {
+    seedTenant(db, "tenant-a");
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-1",
+      channel: "whatsapp",
+      routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      previousRouteKeys: ["whatsapp:default:chat:258862678593671@lid"],
+    });
+    const viaLid = stmts.stmtSelectActiveBindingByRouteKey.get(
+      "whatsapp",
+      "whatsapp:default:chat:258862678593671@lid",
+      "whatsapp:default:chat:258862678593671@lid",
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaLid?.binding_id).toBe("bind-1");
+  });
+
+  test("stmtMigrateBindingRouteKeyWithAlias rewrites route_key and appends to previous_route_keys", () => {
+    seedTenant(db, "tenant-a");
+    // Pre-heal state: binding stored under legacy LID routeKey.
+    const legacyRouteKey = "whatsapp:default:chat:258862678593671@lid";
+    const canonicalRouteKey = "whatsapp:default:chat:15550001111@s.whatsapp.net";
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-1",
+      channel: "whatsapp",
+      routeKey: legacyRouteKey,
+    });
+
+    const updatedAt = Date.now();
+    stmts.stmtMigrateBindingRouteKeyWithAlias.run(
+      canonicalRouteKey,
+      legacyRouteKey,
+      updatedAt,
+      "bind-1",
+      "tenant-a",
+    );
+
+    const row = db
+      .prepare(
+        "SELECT route_key, previous_route_keys, updated_at_ms FROM bindings WHERE binding_id = ?",
+      )
+      .get("bind-1") as
+      | {
+          route_key?: unknown;
+          previous_route_keys?: unknown;
+          updated_at_ms?: unknown;
+        }
+      | undefined;
+    expect(row?.route_key).toBe(canonicalRouteKey);
+    expect(JSON.parse(String(row?.previous_route_keys))).toEqual([legacyRouteKey]);
+    expect(row?.updated_at_ms).toBe(updatedAt);
+
+    // Post-heal: lookup by canonical succeeds on route_key, lookup by
+    // legacy LID succeeds via the alias — both resolve to the same binding.
+    const viaCanonical = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      canonicalRouteKey,
+      canonicalRouteKey,
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaCanonical?.binding_id).toBe("bind-1");
+    const viaLid = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      legacyRouteKey,
+      legacyRouteKey,
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaLid?.binding_id).toBe("bind-1");
+  });
+
+  test("alias match is scoped to the same tenant (no cross-tenant leakage)", () => {
+    seedTenant(db, "tenant-a");
+    seedTenant(db, "tenant-b");
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-a",
+      channel: "whatsapp",
+      routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      previousRouteKeys: ["whatsapp:default:chat:258862678593671@lid"],
+    });
+    // Different tenant, no binding for the LID routeKey.
+    const otherTenantLookup = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-b",
+      "whatsapp",
+      "whatsapp:default:chat:258862678593671@lid",
+      "whatsapp:default:chat:258862678593671@lid",
+    ) as { binding_id?: unknown } | undefined;
+    expect(otherTenantLookup).toBeUndefined();
+  });
+
+  test("inactive bindings are not resolved even via alias", () => {
+    seedTenant(db, "tenant-a");
+    seedBinding(db, {
+      tenantId: "tenant-a",
+      bindingId: "bind-1",
+      channel: "whatsapp",
+      routeKey: "whatsapp:default:chat:15550001111@s.whatsapp.net",
+      previousRouteKeys: ["whatsapp:default:chat:258862678593671@lid"],
+      status: "inactive",
+    });
+    const viaLid = stmts.stmtSelectActiveBindingByTenantAndRoute.get(
+      "tenant-a",
+      "whatsapp",
+      "whatsapp:default:chat:258862678593671@lid",
+      "whatsapp:default:chat:258862678593671@lid",
+    ) as { binding_id?: unknown } | undefined;
+    expect(viaLid).toBeUndefined();
+  });
+
+  test("ensureBindingsRouteKeyAliasColumn migrates pre-existing bindings tables", () => {
+    // Simulate a deployment that was created before this column existed:
+    // drop the fresh-schema table, recreate it without `previous_route_keys`,
+    // insert rows, then run the migration and verify the column is added
+    // with the default value. Sanity check for the `ALTER TABLE` path.
+    const legacyDb = new DatabaseSync(":memory:");
+    legacyDb.exec(`
+      CREATE TABLE tenants (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        api_key_hash TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at_ms INTEGER NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      );
+      CREATE TABLE bindings (
+        binding_id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        route_key TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at_ms INTEGER NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      );
+    `);
+    const now = Date.now();
+    legacyDb
+      .prepare(
+        `INSERT INTO bindings (binding_id, tenant_id, channel, scope, route_key, created_at_ms, updated_at_ms)
+         VALUES ('bind-old', 'tenant-a', 'whatsapp', 'chat', 'whatsapp:default:chat:15550002222@s.whatsapp.net', ?, ?)`,
+      )
+      .run(now, now);
+
+    // Re-run the bootstrap; this should ALTER TABLE to add the new column.
+    initializeDatabase(legacyDb);
+
+    const row = legacyDb
+      .prepare("SELECT previous_route_keys FROM bindings WHERE binding_id = ?")
+      .get("bind-old") as { previous_route_keys?: unknown } | undefined;
+    expect(row?.previous_route_keys).toBe("[]");
+  });
+});


### PR DESCRIPTION
## Summary

Mux-server half of the WhatsApp LID boundary fix — pairs with openclaw PR #111 (`fix/whatsapp-lid-at-bridge-boundary`). Together they move the pipeline to canonical `<digits>@s.whatsapp.net` JIDs everywhere while keeping **frozen LID state** (existing cron `delivery.to` targets, `persistedLastTo` entries) working without any user action or bulk migration.

## What this PR does

**Schema**: adds a `bindings.previous_route_keys` column (JSON text, default `'[]'`). `ensureBindingsRouteKeyAliasColumn` adds it via `ALTER TABLE` on pre-existing deployments — idempotent.

**Alias-aware route lookups**: `stmtSelectActiveBindingByRouteKey`, `stmtSelectLiveBindingByRouteKey`, and `stmtSelectActiveBindingByTenantAndRoute` now match a binding whose `route_key` equals the search key **or** whose `previous_route_keys` JSON array contains it. `json_each` from SQLite's JSON1 module ships with `node:sqlite`. Alias match stays tenant-scoped — cannot leak across tenants.

**Inbound heal** (`forwardWhatsAppInboundMessage`): after openclaw's companion bridge fix emits a canonical `chatId` for DMs, this path tries canonical lookup first. If the canonical lookup misses and the bridge provided `remoteJidRaw` in `@lid` form (different from chatId), it tries the LID routeKey. On hit, the binding's `route_key` is rewritten to canonical and the legacy LID routeKey is pushed into `previous_route_keys`. Writes a `whatsapp_binding_healed_from_lid` audit log entry.

A single inbound per existing LID tenant transitions them from LID-keyed to canonical-with-alias. No bulk migration script, no coordinated rollout window.

**`WebInboundMessage`** gains an optional `remoteJidRaw` field so the heal path has the LID available for fallback lookup; snapshot function preserves it through the queue.

## Why alias-retention instead of replace-only

Agent-side state — cron `delivery.to` and persisted session `lastTo` — was captured under the legacy LID form when those crons were created. Openclaw (in mux mode) has no local Baileys credentials, so it can't resolve LID → E.164 itself. Keeping the LID as an alias in `previous_route_keys` means those frozen targets still resolve to the healed binding on every outbound after the upgrade. Replace-only would require a user-visible "recreate your crons" step.

## Tests

New `test/bindings.lid-alias.test.ts` — direct SQLite unit tests, don't depend on server startup:
- default `previous_route_keys='[]'` on fresh bindings.
- Direct `route_key` match.
- Alias `route_key` match (the post-heal outbound path — what unblocks existing cron).
- `stmtMigrateBindingRouteKeyWithAlias` rewrites `route_key` and appends the legacy form to the alias array.
- Cross-tenant isolation — alias match in tenant A does not leak to tenant B.
- Inactive bindings are not resolvable even via alias.
- `ensureBindingsRouteKeyAliasColumn` migrates a pre-existing `bindings` table lacking the column.

Verification:
- `npx vitest run test/bindings.lid-alias.test.ts` — **8/8 pass**.
- `npx vitest run` (full suite, all 10 test files) — **156/156 pass**.

Pre-existing regression: the suite was broken before this PR because PR #110 (iMessage transport) landed `mime-types` + `@photon-ai/advanced-imessage-kit` imports without `pnpm install` being run in this worktree; reinstalling the workspace before testing resolved it.

## Rollout

Merge with openclaw PR #111. Cut phala.19 together. After the mux-server upgrade, the next WhatsApp inbound per existing LID tenant self-heals their binding in place; their pre-existing cron `delivery.to` (LID) continues to resolve via the alias path and starts succeeding immediately. `persistedLastTo` in openclaw sessions self-heals to canonical on the same inbound through the normal `ctx.To = payload.to` write path (which, post–bridge-fix, carries the canonical form). New tenants never touch the LID code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)