### PR TITLE
test: fix pre-existing iMessage lint + mentat-bridge flaky WebFetch test

### DIFF
--- a/extensions/mentat-bridge/index.test.ts
+++ b/extensions/mentat-bridge/index.test.ts
@@ -1311,7 +1311,7 @@ describe("hooks", () => {
       }
     });
 
-    test("passes through when result is below threshold", async () => {
+    test("passes through when re-fetched HTML is too short to index", async () => {
       const { registerTransformToolResultHook } = await import("./hooks/transform-tool-result.js");
       const { SessionReadTracker, DocMetaCache } = await import("./session-state.js");
 
@@ -1331,28 +1331,47 @@ describe("hooks", () => {
         isHealthy: vi.fn(() => true),
         indexContent: vi.fn(),
       };
-      const cfg = { compressThresholdTokens: 5000 }; // high threshold
+      // Note: WebFetch deliberately bypasses `compressThresholdTokens`
+      // (see transform-tool-result.ts — "we always index" comment). The
+      // meaningful early-exit is `html.length <= 50` from `fetchRawHtml`.
+      const cfg = { compressThresholdTokens: 5000 };
 
-      registerTransformToolResultHook(
-        api as never,
-        client as never,
-        cfg as never,
-        new SessionReadTracker(),
-        new DocMetaCache(),
-      );
+      // Mock fetch to return a trivially short body so the length gate
+      // fires and we never reach indexContent. Without this, the test
+      // would hit the live internet and assertions would depend on the
+      // remote server's current response.
+      const origFetch = globalThis.fetch;
+      const shortBody = "<p>hi</p>"; // 9 bytes, well under the 50-char gate
+      globalThis.fetch = vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode(shortBody).buffer,
+      })) as unknown as typeof fetch;
 
-      const result = await handlers[0](
-        {
-          toolName: "WebFetch",
-          params: { url: "https://example.com" },
-          result: { content: [{ type: "text", text: "short result" }] },
-        },
-        { toolName: "WebFetch" },
-      );
+      try {
+        registerTransformToolResultHook(
+          api as never,
+          client as never,
+          cfg as never,
+          new SessionReadTracker(),
+          new DocMetaCache(),
+        );
 
-      // Below threshold — should not index or compress
-      expect(result).toBeUndefined();
-      expect(client.indexContent).not.toHaveBeenCalled();
+        const result = await handlers[0](
+          {
+            toolName: "WebFetch",
+            params: { url: "https://example.com" },
+            result: { content: [{ type: "text", text: "short result" }] },
+          },
+          { toolName: "WebFetch" },
+        );
+
+        // Re-fetched HTML is below the length gate — hook returns without
+        // indexing or rewriting the tool result.
+        expect(result).toBeUndefined();
+        expect(client.indexContent).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = origFetch;
+      }
     });
 
     test("passes through for non-WebFetch tools", async () => {

--- a/mux-server/test/channels.imessage.api.test.ts
+++ b/mux-server/test/channels.imessage.api.test.ts
@@ -77,14 +77,14 @@ async function parseMultipartForm(form: FormData): Promise<{
   // biome-ignore lint/style/noNonNullAssertion: iterating FormData entries
   for (const [key, value] of form.entries()) {
     if (value instanceof Blob) {
-      // `value` is a Blob — when appended via `form.append(key, blob, filename)`
-      // the filename arrives on the File subclass; native FormData constructs a
-      // File wrapper preserving both `name` and `type`.
-      const file = value as File;
+      // `FormDataEntryValue` is `File | string`, so `instanceof Blob`
+      // narrows to `File` directly — native FormData always wraps
+      // `form.append(key, blob, filename)` in a File preserving both
+      // `name` and `type`. No cast needed.
       attachment = {
-        filename: file.name,
-        contentType: file.type,
-        body: Buffer.from(await file.arrayBuffer()),
+        filename: value.name,
+        contentType: value.type,
+        body: Buffer.from(await value.arrayBuffer()),
       };
     } else {
       fields[key] = String(value);


### PR DESCRIPTION
Two small test-only fixes required to unblock `pnpm check` on the `phala-2026.3.13` branch. Both pre-existed — neither is caused by any in-flight WhatsApp-LID PRs — but together they block the `pnpm check` pipeline.

## Fix 1: `mux-server/test/channels.imessage.api.test.ts` — drop unnecessary `as File` cast

`FormDataEntryValue = File | string`, so `instanceof Blob` already narrows `value` to `File`. The explicit cast was flagged by oxlint's type-aware `typescript-eslint(no-unnecessary-type-assertion)`, halting `pnpm lint` with 1 error.

## Fix 2: `extensions/mentat-bridge/index.test.ts` — WebFetch passthrough test premise was wrong

The test "passes through when result is below threshold" expected `compressThresholdTokens` to gate WebFetch indexing. But `transform-tool-result.ts:89-92` **explicitly documents** that WebFetch bypasses the threshold ("we always index — the raw HTML has far more content than the extracted markdown returned by the tool, so token-based gating on the tool result would almost always skip").

Additionally, the test didn't mock `globalThis.fetch`, so the hook's internal `fetchRawHtml` hit the **live internet**. The test passed only when example.com's response happened to be shorter than the `html.length > 50` gate — otherwise it failed with a diff showing real Example.com HTML bytes.

Rewrote to match the hook's actual early-exit (HTML too short) with a properly mocked `fetch`, preserving the test's passthrough intent and removing the live-network dependency.

## Verification

- `pnpm lint` — 0 errors (was 1).
- `npx vitest run extensions/mentat-bridge/index.test.ts` — **92 passed / 35 skipped** (was 91 / 35 / **1 failed**).
- `npx vitest run mux-server/test/channels.imessage.api.test.ts` — 27/27 pass, no behavior change.
- `pnpm check` at repo root — exits 0, full chain green.

Unblocks the WhatsApp-LID follow-up PRs (#111 openclaw, #112 mux-server) whose `pnpm check` otherwise halts at these pre-existing errors before reaching their own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)