### PR TITLE
channels: per-account apiBaseUrl + wsUrl for proxy routing

### DIFF
--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -111,6 +111,10 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   enabled: z.boolean().optional(),
   /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
   authDir: z.string().optional(),
+  /** Override the Baileys WebSocket URL for this account. Points Baileys at
+   *  msg-router's Noise WS face instead of `wss://web.whatsapp.com/ws/chat`.
+   *  Same role as `apiBaseUrl` on TG/Discord accounts. */
+  wsUrl: z.string().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
 }).strict();
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -755,15 +755,18 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       {
         // Carbon uses `baseUrl` on the Client for its own interaction/deploy
         // URL construction and `requestOptions.baseUrl` on the REST client
-        // it builds internally; set both so DISCORD_BOT_API_BASE_URL
-        // redirects every outbound REST call (default: real Discord).
-        baseUrl: resolveDiscordApiBaseUrl(),
+        // it builds internally. Pass the per-account config so
+        // `channels.discord.accounts.<id>.apiBaseUrl` is honored — without
+        // it, both fall back to https://discord.com and the agent ends up
+        // talking to real Discord with a synthetic msg-router-minted token
+        // (=> 401 on every REST call).
+        baseUrl: resolveDiscordApiBaseUrl(process.env, rawDiscordCfg),
         requestOptions: {
           // Carbon's request paths look like `/applications/.../commands`
           // without an `/api/vN` prefix, so our override must include the
           // full `/api/v10` suffix. That matches both real Discord and
           // msg-router's emulator (which canonicalizes with the prefix).
-          baseUrl: `${resolveDiscordApiBaseUrl()}/api/v10`,
+          baseUrl: `${resolveDiscordApiBaseUrl(process.env, rawDiscordCfg)}/api/v10`,
         },
         deploySecret: "a",
         clientId: applicationId,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -535,7 +535,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     phase: "fetch-application-id:start",
     startAt: startupStartedAt,
   });
-  const applicationId = await fetchDiscordApplicationId(token, 4000, discordRestFetch);
+  const applicationId = await fetchDiscordApplicationId(
+    token,
+    4000,
+    discordRestFetch,
+    resolveDiscordApiBaseUrl(process.env, rawDiscordCfg),
+  );
   if (!applicationId) {
     throw new Error("Failed to resolve Discord application id");
   }

--- a/src/discord/probe.ts
+++ b/src/discord/probe.ts
@@ -56,13 +56,15 @@ async function fetchDiscordApplicationMeResponse(
   token: string,
   timeoutMs: number,
   fetcher: typeof fetch,
+  baseUrl?: string,
 ): Promise<Response | undefined> {
   const normalized = normalizeDiscordToken(token, "channels.discord.token");
   if (!normalized) {
     return undefined;
   }
+  const apiBase = baseUrl ? `${baseUrl}/api/v10` : discordApiBase();
   return await fetchWithTimeout(
-    `${discordApiBase()}/oauth2/applications/@me`,
+    `${apiBase}/oauth2/applications/@me`,
     { headers: { Authorization: `Bot ${normalized}` } },
     timeoutMs,
     getResolvedFetch(fetcher),
@@ -208,13 +210,14 @@ export async function fetchDiscordApplicationId(
   token: string,
   timeoutMs: number,
   fetcher: typeof fetch = fetch,
+  baseUrl?: string,
 ): Promise<string | undefined> {
   const normalized = normalizeDiscordToken(token, "channels.discord.token");
   if (!normalized) {
     return undefined;
   }
   try {
-    const res = await fetchDiscordApplicationMeResponse(token, timeoutMs, fetcher);
+    const res = await fetchDiscordApplicationMeResponse(token, timeoutMs, fetcher, baseUrl);
     if (!res) {
       return undefined;
     }

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -29,6 +29,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  wsUrl?: string;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -146,6 +147,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    wsUrl: (accountCfg as { wsUrl?: string } | undefined)?.wsUrl ?? undefined,
   };
 }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -196,6 +196,7 @@ export async function monitorWebChannel(
       verbose,
       accountId: account.accountId,
       authDir: account.authDir,
+      wsUrl: account.wsUrl,
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -26,6 +26,7 @@ export async function monitorWebInbox(options: {
   verbose: boolean;
   accountId: string;
   authDir: string;
+  wsUrl?: string;
   onMessage: (msg: WebInboundMessage) => Promise<void>;
   /**
    * Optional access-control resolver override.
@@ -58,6 +59,7 @@ export async function monitorWebInbox(options: {
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
+    wsUrl: options.wsUrl,
   });
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -91,7 +91,7 @@ async function safeSaveCreds(
 export async function createWaSocket(
   printQr: boolean,
   verbose: boolean,
-  opts: { authDir?: string; onQr?: (qr: string) => void } = {},
+  opts: { authDir?: string; onQr?: (qr: string) => void; wsUrl?: string } = {},
 ): Promise<ReturnType<typeof makeWASocket>> {
   const baseLogger = getChildLogger(
     { module: "baileys" },
@@ -111,7 +111,7 @@ export async function createWaSocket(
   // (see docs/MIGRATION-FROM-MUX.md) and direct msg-router deployments to
   // route WA through msg-router's Noise WS face. Undefined → Baileys uses
   // its real-WA default.
-  const waWebSocketUrl = resolveWaWebSocketUrl();
+  const waWebSocketUrl = resolveWaWebSocketUrl(process.env, { wsUrl: opts.wsUrl });
   const sock = makeWASocket({
     auth: {
       creds: state.creds,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -122,7 +122,7 @@ export async function createWaSocket(
     printQRInTerminal: false,
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
-    markOnlineOnConnect: false,
+    markOnlineOnConnect: true,
     ...(waWebSocketUrl ? { waWebSocketUrl } : {}),
   });
 

--- a/src/web/wa-websocket-url.ts
+++ b/src/web/wa-websocket-url.ts
@@ -1,14 +1,16 @@
 /**
  * Resolve the WhatsApp Noise WebSocket URL Baileys should connect to.
  *
- * Default (env unset): Baileys' own default (`wss://web.whatsapp.com/ws/chat`).
- * Override via `WA_WEBSOCKET_URL` env to point Baileys at an msg-router
- * Noise WS face — the mechanism by which a nested mux-server deployment
- * (see `docs/MIGRATION-FROM-MUX.md`) or a direct openclaw deployment can
- * route WhatsApp traffic through msg-router rather than real WA.
+ * Default (env unset, no per-account override): Baileys' own default
+ * (`wss://web.whatsapp.com/ws/chat`).
  *
- * Mirrors the shape of the Telegram / Discord base-URL resolvers so the
- * three channels expose the same operator-facing knob style.
+ * Precedence:
+ *   1. `account.wsUrl` (per-account config override).
+ *   2. `WA_WEBSOCKET_URL` env var (process-wide override).
+ *   3. undefined → Baileys uses its default.
+ *
+ * Mirrors the shape of the Telegram / Discord `apiBaseUrl` resolvers so
+ * all three channels expose the same operator-facing knob style.
  */
 export const WA_WEBSOCKET_URL_ENV = "WA_WEBSOCKET_URL";
 
@@ -17,12 +19,16 @@ function normalizeWaWebSocketUrl(value: string | null | undefined): string | nul
   if (!trimmed) {
     return null;
   }
-  // Strip trailing slashes to avoid double-slash URLs when Baileys appends
-  // paths internally. Preserve a leading `ws://` / `wss://`; anything else
-  // is passed through unchanged so callers can use URL objects too.
   return trimmed.replace(/\/+$/, "") || null;
 }
 
-export function resolveWaWebSocketUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+export function resolveWaWebSocketUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  account?: { wsUrl?: string },
+): string | undefined {
+  const perAccount = normalizeWaWebSocketUrl(account?.wsUrl);
+  if (perAccount) {
+    return perAccount;
+  }
   return normalizeWaWebSocketUrl(env[WA_WEBSOCKET_URL_ENV]) ?? undefined;
 }


### PR DESCRIPTION
## Summary

Lets each channel account override its upstream URL via config (no global env vars):

- **Discord**: `channels.discord.accounts.<id>.apiBaseUrl` — already plumbed for runtime; this commit also threads it through `fetchDiscordApplicationId` so the startup probe hits the proxy instead of `discord.com`. Eliminates the `DISCORD_BOT_API_BASE_URL` env workaround.
- **WhatsApp**: new `channels.whatsapp.accounts.<id>.wsUrl` mirrors the same pattern; precedence is `account.wsUrl > WA_WEBSOCKET_URL env > Baileys default`. Threaded through `resolveWhatsAppAccount → monitorWebInbox → createWaSocket`.
- **WhatsApp**: `markOnlineOnConnect: true` (linked-device visibility — without this, senders silently drop the device from their cache).

## Why

Drives the msg-router migration. m031 sets `apiBaseUrl`/`wsUrl` on each account when a tenant is moved off mux-server onto the direct msg-router data plane. Avoiding global env vars means a single OpenClaw process can host accounts that point at different proxies — necessary for the per-tenant migration model.

## Test plan

- [ ] TG: existing `apiBaseUrl` path unchanged
- [ ] Discord: with `apiBaseUrl` set, application-id probe hits the proxy and gateway connects without `DISCORD_BOT_API_BASE_URL`
- [ ] WhatsApp: with `wsUrl` set, Baileys connects to the override; without it, env var still works; without either, connects to default Baileys URL
- [ ] WhatsApp linked-device flow: senders see the device persist after reconnects (markOnlineOnConnect)

🤖 Validated against the msg-router migration rehearsal (Stage 1 + Stage 2).