### PR TITLE
fix(whatsapp): mark linked device online on connect

### DIFF
--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -122,7 +122,7 @@ export async function createWaSocket(
     printQRInTerminal: false,
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
-    markOnlineOnConnect: false,
+    markOnlineOnConnect: true,
     ...(waWebSocketUrl ? { waWebSocketUrl } : {}),
   });
 


### PR DESCRIPTION
## Summary
- Set Baileys `markOnlineOnConnect` to `true` for the shared WhatsApp runtime used by mux-server/OpenClaw.
- Keeps linked-device sessions visible after reconnect during msg-router migration.

## Test plan
- `pnpm exec vitest run --config vitest.channels.config.ts src/web/wa-websocket-url.test.ts src/web/wa-websocket-url.integration.test.ts`