### PR TITLE
fix(discord): pass account config to probes

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -414,6 +414,7 @@ describe("discordPlugin outbound", () => {
     });
 
     const cfg = createCfg();
+    cfg.channels!.discord!.apiBaseUrl = "https://msg-router.example";
     const account = resolveAccount(cfg);
 
     await discordPlugin.status!.probeAccount!({
@@ -424,6 +425,9 @@ describe("discordPlugin outbound", () => {
 
     expect(probeDiscordMock).toHaveBeenCalledWith("discord-token", 5000, {
       includeApplication: true,
+      account: expect.objectContaining({
+        apiBaseUrl: "https://msg-router.example",
+      }),
     });
     expect(runtimeProbeDiscord).not.toHaveBeenCalled();
   });
@@ -487,11 +491,15 @@ describe("discordPlugin outbound", () => {
     monitorDiscordProviderMock.mockResolvedValue(undefined);
 
     const cfg = createCfg();
+    cfg.channels!.discord!.apiBaseUrl = "https://msg-router.example";
     await startDiscordAccount(cfg);
 
     await vi.waitFor(() =>
       expect(probeDiscordMock).toHaveBeenCalledWith("discord-token", 2500, {
         includeApplication: true,
+        account: expect.objectContaining({
+          apiBaseUrl: "https://msg-router.example",
+        }),
       }),
     );
     const monitorParams = objectArgAt(monitorDiscordProviderMock, 0, 0);
@@ -550,6 +558,9 @@ describe("discordPlugin outbound", () => {
     await vi.waitFor(() =>
       expect(probeDiscordMock).toHaveBeenCalledWith("discord-token", 2500, {
         includeApplication: true,
+        account: expect.objectContaining({
+          token: "discord-token",
+        }),
       }),
     );
     expect(statusPatches.filter((patch) => "bot" in patch || "application" in patch)).toEqual([]);

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -105,6 +105,7 @@ const discordMessageAdapter = createChannelMessageAdapterFromOutbound({
 function startDiscordStartupProbe(params: {
   accountId: string;
   token: string;
+  accountConfig: ResolvedDiscordAccount["config"];
   abortSignal: AbortSignal;
   setStatus: (patch: { accountId: string; bot?: unknown; application?: unknown }) => void;
   log?: {
@@ -119,6 +120,7 @@ function startDiscordStartupProbe(params: {
         await loadDiscordProbeRuntime()
       ).probeDiscord(params.token, 2500, {
         includeApplication: true,
+        account: params.accountConfig,
       });
       if (params.abortSignal.aborted) {
         return;
@@ -491,6 +493,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
         probeAccount: async ({ account, timeoutMs }) =>
           (await loadDiscordProbeRuntime()).probeDiscord(account.token, timeoutMs, {
             includeApplication: true,
+            account: account.config,
           }),
         formatCapabilitiesProbe: ({ probe }) => {
           const discordProbe = probe as DiscordProbe | undefined;
@@ -671,6 +674,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
           startDiscordStartupProbe({
             accountId: account.accountId,
             token,
+            accountConfig: account.config,
             abortSignal: ctx.abortSignal,
             setStatus: ctx.setStatus,
             log: ctx.log,


### PR DESCRIPTION
## Summary
- pass resolved Discord account config into status and startup probes
- keeps msg-router apiBaseUrl active for /users/@me and application probes
- adds regression coverage for status/startup probe options

## Tests
- ./node_modules/.bin/vitest run extensions/discord/src/channel.test.ts